### PR TITLE
Changed function calls to use parameter names

### DIFF
--- a/src/OnCommand-Insight.psm1
+++ b/src/OnCommand-Insight.psm1
@@ -24,22 +24,22 @@ if ($PSVersionTable.PSVersion.Major -lt 6) {
     # Functions necessary to parse JSON output from .NET serializer to PowerShell Objects
     function ParseItem($jsonItem) {
         if($jsonItem.PSObject.TypeNames -match "Array") {
-            return ParseJsonArray($jsonItem)
+            return ParseJsonArray -jsonArray $jsonItem
         }
         elseif($jsonItem.PSObject.TypeNames -match "Dictionary") {
-            return ParseJsonObject([HashTable]$jsonItem)
+            return ParseJsonObject -jsonObj [HashTable]$jsonItem
         }
         else {
             return $jsonItem
         }
     }
- 
+
     function ParseJsonObject($jsonObj) {
         $result = New-Object -TypeName PSCustomObject
         foreach ($key in $jsonObj.Keys) {
             $item = $jsonObj[$key]
             if ($item) {
-                $parsedItem = ParseItem $item
+                $parsedItem = ParseItem -jsonItem $item
             } else {
                 $parsedItem = $null
             }
@@ -47,22 +47,22 @@ if ($PSVersionTable.PSVersion.Major -lt 6) {
         }
         return $result
     }
- 
+
     function ParseJsonArray($jsonArray) {
         $result = @()
         $jsonArray | ForEach-Object {
-            $result += ,(ParseItem $_)
+            $result += ,(ParseItem -jsonItem $_)
         }
         return $result
     }
- 
+
     function ParseJsonString($json) {
         $config = $javaScriptSerializer.DeserializeObject($json)
         if ($config -is [Array]) {
-            return ParseJsonArray($config)       
+            return ParseJsonArray -jsonArray $config
         }
         else {
-            return ParseJsonObject($config)
+            return ParseJsonObject -jsonObj $config
         }
     }
 }
@@ -95,7 +95,7 @@ function global:Invoke-MultipartFormDataUpload
         Add-Type -AssemblyName System.Web
 
         $mimeType = [System.Web.MimeMapping]::GetMimeMapping($InFile)
-            
+
         if ($mimeType)
         {
             $ContentType = $mimeType
@@ -121,7 +121,7 @@ function global:Invoke-MultipartFormDataUpload
         $httpClient.Timeout = 864000000000
 
         $packageFileStream = New-Object System.IO.FileStream @($InFile, [System.IO.FileMode]::Open)
-        
+
 		$contentDispositionHeaderValue = New-Object System.Net.Http.Headers.ContentDispositionHeaderValue "form-data"
 	    $contentDispositionHeaderValue.Name = $Name
 		$contentDispositionHeaderValue.FileName = (Split-Path $InFile -leaf)
@@ -129,7 +129,7 @@ function global:Invoke-MultipartFormDataUpload
         $streamContent = New-Object System.Net.Http.StreamContent $packageFileStream
         $streamContent.Headers.ContentDisposition = $contentDispositionHeaderValue
         $streamContent.Headers.ContentType = New-Object System.Net.Http.Headers.MediaTypeHeaderValue $ContentType
-        
+
         $content = New-Object System.Net.Http.MultipartFormDataContent
         $content.Add($streamContent)
 
@@ -171,7 +171,7 @@ function global:Invoke-MultipartFormDataUpload
 # helper function to convert datetime to unix timestamp
 function ConvertTo-UnixTimestamp {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -181,7 +181,7 @@ function ConvertTo-UnixTimestamp {
     )
 
     BEGIN {
-        $epoch = Get-Date -Year 1970 -Month 1 -Day 1 -Hour 0 -Minute 0 -Second 0  
+        $epoch = Get-Date -Year 1970 -Month 1 -Day 1 -Hour 0 -Minute 0 -Second 0
     }
 
     PROCESS {
@@ -190,10 +190,10 @@ function ConvertTo-UnixTimestamp {
         foreach ($Date in $Date) {
                 $milliSeconds = [math]::truncate($Date.ToUniversalTime().Subtract($epoch).TotalMilliSeconds)
                 Write-Output $milliSeconds
-        }    
-    } 
+        }
+    }
 }
- 
+
 # helper function to convert unix timestamp to datetime
 function ConvertFrom-UnixTimestamp {
     [CmdletBinding()]
@@ -231,7 +231,7 @@ function ConvertTo-AnnotationValues {
           )
 
     PROCESS {
-        $AnnotationValues = $Annotations | ? { $_.label } | % { [PSCustomObject]@{rawValue=$_.rawValue;label=$_.label;isDerived=$false;annotationAssignment="MANUAL";definition=$_} | Add-Member -MemberType AliasProperty -Name displayValue -Value rawValue -PassThru }
+        $AnnotationValues = $Annotations | Where-Object { $_.label } | ForEach-Object { [PSCustomObject]@{rawValue=$_.rawValue;label=$_.label;isDerived=$false;annotationAssignment="MANUAL";definition=$_} | Add-Member -MemberType AliasProperty -Name displayValue -Value rawValue -PassThru }
         Write-Output $AnnotationValues
     }
 }
@@ -266,8 +266,8 @@ function ParseAcquisitionUnits($AcquisitionUnits) {
         }
 
         if ($AcquisitionUnit.datasources) {
-            $AcquisitionUnit.datasources = ParseDatasources($AcquisitionUnit.datasources)
-        } 
+            $AcquisitionUnit.datasources = ParseDatasources -Datasources $AcquisitionUnit.datasources
+        }
 
         Write-Output $AcquisitionUnit
     }
@@ -298,19 +298,19 @@ function ParseDatasources($Datasources) {
             $Datasource.resumeTime = $Datasource.resumeTime | Get-Date
         }
         if ($Datasource.AcquisitionUnit) {
-            $Datasource.AcquisitionUnit = ParseAcquisitionUnits($Datasource.AcquisitionUnit)
+            $Datasource.AcquisitionUnit = ParseAcquisitionUnits -AcquisitionUnits $Datasource.AcquisitionUnit
         }
         if ($Datasource.Changes) {
-            $Datasource.Changes = ParseChanges($Datasource.Changes)
+            $Datasource.Changes = ParseChanges -Changes $Datasource.Changes
         }
         if ($Datasource.Events) {
-            $Datasource.Events = ParseEvents($Datasource.Events)
+            $Datasource.Events = ParseEvents -Events $Datasource.Events
         }
         if ($Datasource.activePatch) {
-            $Datasource.activePatch = ParseActivePatches($Datasource.activePatch)
+            $Datasource.activePatch = ParseActivePatches -ActivePatches $Datasource.activePatch
         }
         if ($Datasource.config) {
-            $Datasource.config = ParseDatasourceConfig($Datasource.config)
+            $Datasource.config = ParseDatasourceConfig -DatasourceConfig $Datasource.config
         }
         Write-Output $Datasource
     }
@@ -326,8 +326,8 @@ function ParseDatasourceTypes($DatasourceTypes) {
 function ParseDatasourceConfig($DatasourceConfig) {
     $DatasourceConfig = @($DatasourceConfig)
     foreach ($DatasourceConfig in $DatasourceConfig) {
-        if ($DatasourceConfig.packages | ? { $_.id -eq "foundation" }) {
-            $DatasourceConfig | Add-Member -MemberType ScriptProperty -Name "foundation" -Value { $this.packages | ? { $_.id -eq "foundation" } }
+        if ($DatasourceConfig.packages | Where-Object { $_.id -eq "foundation" }) {
+            $DatasourceConfig | Add-Member -MemberType ScriptProperty -Name "foundation" -Value { $this.packages | Where-Object { $_.id -eq "foundation" } }
             if (!$DatasourceConfig.foundation.attributes.password) {
                 $DatasourceConfig.foundation.attributes | Add-Member -MemberType NoteProperty -Name password -Value "" -force
             }
@@ -335,17 +335,17 @@ function ParseDatasourceConfig($DatasourceConfig) {
                 $DatasourceConfig.foundation.attributes | Add-Member -MemberType NoteProperty -Name 'partner.password' -Value "" -force
             }
         }
-        if ($DatasourceConfig.packages | ? { $_.id -eq "storageperformance" }) {
-            $DatasourceConfig | Add-Member -MemberType ScriptProperty -Name "storageperformance" -Value { $this.packages | ? { $_.id -eq "storageperformance" } }
+        if ($DatasourceConfig.packages | Where-Object { $_.id -eq "storageperformance" }) {
+            $DatasourceConfig | Add-Member -MemberType ScriptProperty -Name "storageperformance" -Value { $this.packages | Where-Object { $_.id -eq "storageperformance" } }
         }
-        if ($DatasourceConfig.packages | ? { $_.id -eq "hostvirtualization" }) {
-            $DatasourceConfig | Add-Member -MemberType ScriptProperty -Name "hostvirtualization" -Value { $this.packages | ? { $_.id -eq "hostvirtualization" } }
+        if ($DatasourceConfig.packages | Where-Object { $_.id -eq "hostvirtualization" }) {
+            $DatasourceConfig | Add-Member -MemberType ScriptProperty -Name "hostvirtualization" -Value { $this.packages | Where-Object { $_.id -eq "hostvirtualization" } }
         }
-        if ($DatasourceConfig.packages | ? { $_.id -eq "performance" }) {
-            $DatasourceConfig | Add-Member -MemberType ScriptProperty -Name "performance" -Value { $this.packages | ? { $_.id -eq "performance" } }
+        if ($DatasourceConfig.packages | Where-Object { $_.id -eq "performance" }) {
+            $DatasourceConfig | Add-Member -MemberType ScriptProperty -Name "performance" -Value { $this.packages | Where-Object { $_.id -eq "performance" } }
         }
-        if ($DatasourceConfig.packages | ? { $_.id -eq "cloud" }) {
-            $DatasourceConfig | Add-Member -MemberType ScriptProperty -Name "cloud" -Value { $this.packages | ? { $_.id -eq "cloud" } }
+        if ($DatasourceConfig.packages | Where-Object { $_.id -eq "cloud" }) {
+            $DatasourceConfig | Add-Member -MemberType ScriptProperty -Name "cloud" -Value { $this.packages | Where-Object { $_.id -eq "cloud" } }
         }
         Write-Output $DatasourceConfig
     }
@@ -388,7 +388,7 @@ function ParseCertificates($Certificates) {
 }
 
 function ParseLicenseStatus($LicenseStatus) {
-    $LicenseStatus.LicenseParts = ParseLicenses($LicenseStatus.LicenseParts)
+    $LicenseStatus.LicenseParts = ParseLicenses -Licenses $LicenseStatus.LicenseParts
 
     Write-Output $LicenseStatus
 }
@@ -419,7 +419,7 @@ function ParseDatastores($Datastores,$Timezone) {
     $Datastores = @($Datastores)
     foreach ($Datastore in $Datastores) {
         if ($Datastore.performance) {
-            $Datastore.performance = ParsePerformance $Datastore.performance $Timezone
+            $Datastore.performance = ParsePerformance -Performance $Datastore.performance -Timezone $Timezone
         }
 
         Write-Output $Datastore
@@ -433,22 +433,22 @@ function ParseSwitches($Switches,$Timezone) {
             $Switch.createTime = $Switch.createTime | Get-Date
         }
         if ($Switch.performance) {
-            $Switch.performance = ParsePerformance $Switch.performance $Timezone
+            $Switch.performance = ParsePerformance -Performance $Switch.performance -Timezone $Timezone
         }
         if ($Switch.fabric) {
-            $Switch.fabric = ParseFabrics($Switch.fabric)
+            $Switch.fabric = ParseFabrics -Fabrics $Switch.fabric
         }
         if ($Switch.ports) {
-            $Switch.ports = ParsePorts $Switch.ports $Timezone
+            $Switch.ports = ParsePorts -Ports $Switch.ports -Timezone $Timezone
         }
         if ($Switch.annotations) {
-            $Switch.annotations = ParseAnnotations($Switch.annotations)
+            $Switch.annotations = ParseAnnotations -Annotations $Switch.annotations
         }
         if ($Switch.datasources) {
-            $Switch.datasources = ParseDatasources($Switch.datasources)
+            $Switch.datasources = ParseDatasources -Datasources $Switch.datasources
         }
         if ($Switch.applications) {
-            $Switch.applications = ParseApplications($Switch.applications)
+            $Switch.applications = ParseApplications -Applications $Switch.applications
         }
 
         Write-Output $Switch
@@ -457,125 +457,125 @@ function ParseSwitches($Switches,$Timezone) {
 
 function ParsePerformance($Performance,$Timezone) {
     if ($Performance.accessed) {
-        $Performance.accessed.start = $Performance.accessed.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.accessed.end = $Performance.accessed.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.accessed.start = $Performance.accessed.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.accessed.end = $Performance.accessed.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
     }
     if ($Performance.cacheHitRatio) {
         if ($Performance.cacheHitRatio.read) {
-            $Performance.cacheHitRatio.read.start = $Performance.cacheHitRatio.read.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-            $Performance.cacheHitRatio.read.end = $Performance.cacheHitRatio.read.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+            $Performance.cacheHitRatio.read.start = $Performance.cacheHitRatio.read.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+            $Performance.cacheHitRatio.read.end = $Performance.cacheHitRatio.read.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
         }
         if ($Performance.cacheHitRatio.write) {
-            $Performance.cacheHitRatio.write.start = $Performance.cacheHitRatio.write.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-            $Performance.cacheHitRatio.write.end = $Performance.cacheHitRatio.write.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+            $Performance.cacheHitRatio.write.start = $Performance.cacheHitRatio.write.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+            $Performance.cacheHitRatio.write.end = $Performance.cacheHitRatio.write.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
         }
         if ($Performance.cacheHitRatio.total) {
-            $Performance.cacheHitRatio.total.start = $Performance.cacheHitRatio.total.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-            $Performance.cacheHitRatio.total.end = $Performance.cacheHitRatio.total.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+            $Performance.cacheHitRatio.total.start = $Performance.cacheHitRatio.total.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+            $Performance.cacheHitRatio.total.end = $Performance.cacheHitRatio.total.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
         }
     }
     if ($Performance.cpuUtilization) {
-        $Performance.cpuUtilization.total.start = $Performance.cpuUtilization.total.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.cpuUtilization.total.end = $Performance.cpuUtilization.total.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.cpuUtilization.total.start = $Performance.cpuUtilization.total.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.cpuUtilization.total.end = $Performance.cpuUtilization.total.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
     }
     if ($Performance.diskIops) {
-        $Performance.diskIops.read.start = $Performance.diskIops.read.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.diskIops.read.end = $Performance.diskIops.read.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.diskIops.write.start = $Performance.diskIops.write.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.diskIops.write.end = $Performance.diskIops.write.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.diskIops.totalMax.start = $Performance.diskIops.totalMax.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.diskIops.totalMax.end = $Performance.diskIops.totalMax.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.diskIops.total.start = $Performance.diskIops.total.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.diskIops.total.end = $Performance.diskIops.total.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.diskIops.read.start = $Performance.diskIops.read.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.diskIops.read.end = $Performance.diskIops.read.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.diskIops.write.start = $Performance.diskIops.write.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.diskIops.write.end = $Performance.diskIops.write.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.diskIops.totalMax.start = $Performance.diskIops.totalMax.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.diskIops.totalMax.end = $Performance.diskIops.totalMax.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.diskIops.total.start = $Performance.diskIops.total.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.diskIops.total.end = $Performance.diskIops.total.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
     }
     if ($Performance.diskLatency) {
-        $Performance.diskLatency.read.start = $Performance.diskLatency.read.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.diskLatency.read.end = $Performance.diskLatency.read.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.diskLatency.write.start = $Performance.diskLatency.write.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.diskLatency.write.end = $Performance.diskLatency.write.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.diskLatency.total.start = $Performance.diskLatency.total.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.diskLatency.total.end = $Performance.diskLatency.total.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.diskLatency.totalMax.start = $Performance.diskLatency.totalMax.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.diskLatency.totalMax.end = $Performance.diskLatency.totalMax.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.diskLatency.read.start = $Performance.diskLatency.read.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.diskLatency.read.end = $Performance.diskLatency.read.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.diskLatency.write.start = $Performance.diskLatency.write.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.diskLatency.write.end = $Performance.diskLatency.write.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.diskLatency.total.start = $Performance.diskLatency.total.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.diskLatency.total.end = $Performance.diskLatency.total.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.diskLatency.totalMax.start = $Performance.diskLatency.totalMax.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.diskLatency.totalMax.end = $Performance.diskLatency.totalMax.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
     }
     if ($Performance.diskThroughput) {
-        $Performance.diskThroughput.read.start = $Performance.diskThroughput.read.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.diskThroughput.read.end = $Performance.diskThroughput.read.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.diskThroughput.write.start = $Performance.diskThroughput.write.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.diskThroughput.write.end = $Performance.diskThroughput.write.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.diskThroughput.totalMax.start = $Performance.diskThroughput.totalMax.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.diskThroughput.totalMax.end = $Performance.diskThroughput.totalMax.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.diskThroughput.total.start = $Performance.diskThroughput.total.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.diskThroughput.total.end = $Performance.diskThroughput.total.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.diskThroughput.read.start = $Performance.diskThroughput.read.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.diskThroughput.read.end = $Performance.diskThroughput.read.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.diskThroughput.write.start = $Performance.diskThroughput.write.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.diskThroughput.write.end = $Performance.diskThroughput.write.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.diskThroughput.totalMax.start = $Performance.diskThroughput.totalMax.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.diskThroughput.totalMax.end = $Performance.diskThroughput.totalMax.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.diskThroughput.total.start = $Performance.diskThroughput.total.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.diskThroughput.total.end = $Performance.diskThroughput.total.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
     }
     if ($Performance.fcWeightedPortBalanceIndex) {
-        $Performance.fcWeightedPortBalanceIndex.start = $Performance.fcWeightedPortBalanceIndex.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.fcWeightedPortBalanceIndex.end = $Performance.fcWeightedPortBalanceIndex.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.fcWeightedPortBalanceIndex.start = $Performance.fcWeightedPortBalanceIndex.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.fcWeightedPortBalanceIndex.end = $Performance.fcWeightedPortBalanceIndex.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
     }
     if ($Performance.iops) {
-        $Performance.iops.read.start = $Performance.iops.read.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.iops.read.end = $Performance.iops.read.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.iops.write.start = $Performance.iops.write.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.iops.write.end = $Performance.iops.write.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.iops.totalMax.start = $Performance.iops.totalMax.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.iops.totalMax.end = $Performance.iops.totalMax.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.iops.total.start = $Performance.iops.total.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.iops.total.end = $Performance.iops.total.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.iops.read.start = $Performance.iops.read.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.iops.read.end = $Performance.iops.read.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.iops.write.start = $Performance.iops.write.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.iops.write.end = $Performance.iops.write.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.iops.totalMax.start = $Performance.iops.totalMax.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.iops.totalMax.end = $Performance.iops.totalMax.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.iops.total.start = $Performance.iops.total.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.iops.total.end = $Performance.iops.total.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
     }
     if ($Performance.ipThroughput) {
-        $Performance.ipThroughput.read.start = $Performance.ipThroughput.read.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.ipThroughput.read.end = $Performance.ipThroughput.read.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.ipThroughput.write.start = $Performance.ipThroughput.write.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.ipThroughput.write.end = $Performance.ipThroughput.write.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.ipThroughput.totalMax.start = $Performance.ipThroughput.totalMax.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.ipThroughput.totalMax.end = $Performance.ipThroughput.totalMax.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.ipThroughput.total.start = $Performance.ipThroughput.total.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.ipThroughput.total.end = $Performance.ipThroughput.total.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.ipThroughput.read.start = $Performance.ipThroughput.read.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.ipThroughput.read.end = $Performance.ipThroughput.read.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.ipThroughput.write.start = $Performance.ipThroughput.write.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.ipThroughput.write.end = $Performance.ipThroughput.write.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.ipThroughput.totalMax.start = $Performance.ipThroughput.totalMax.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.ipThroughput.totalMax.end = $Performance.ipThroughput.totalMax.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.ipThroughput.total.start = $Performance.ipThroughput.total.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.ipThroughput.total.end = $Performance.ipThroughput.total.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
     }
     if ($Performance.latency) {
-        $Performance.latency.read.start = $Performance.latency.read.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.latency.read.end = $Performance.latency.read.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.latency.write.start = $Performance.latency.write.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.latency.write.end = $Performance.latency.write.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.latency.total.start = $Performance.latency.total.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.latency.total.end = $Performance.latency.total.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.latency.totalMax.start = $Performance.latency.totalMax.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.latency.totalMax.end = $Performance.latency.totalMax.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.latency.read.start = $Performance.latency.read.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.latency.read.end = $Performance.latency.read.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.latency.write.start = $Performance.latency.write.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.latency.write.end = $Performance.latency.write.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.latency.total.start = $Performance.latency.total.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.latency.total.end = $Performance.latency.total.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.latency.totalMax.start = $Performance.latency.totalMax.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.latency.totalMax.end = $Performance.latency.totalMax.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
     }
     if ($Performance.memoryUtilization) {
-        $Performance.memoryUtilization.total.start = $Performance.memoryUtilization.total.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.memoryUtilization.total.end = $Performance.memoryUtilization.total.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.memoryUtilization.total.start = $Performance.memoryUtilization.total.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.memoryUtilization.total.end = $Performance.memoryUtilization.total.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
     }
     if ($Performance.partialBlocksRatio.total) {
-        $Performance.partialBlocksRatio.total.start = $Performance.partialBlocksRatio.total.start | ? { $_ } | ConvertFrom-UnixTimestamp
-        $Performance.partialBlocksRatio.total.end = $Performance.partialBlocksRatio.total.end | ? { $_ } | ConvertFrom-UnixTimestamp
+        $Performance.partialBlocksRatio.total.start = $Performance.partialBlocksRatio.total.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp
+        $Performance.partialBlocksRatio.total.end = $Performance.partialBlocksRatio.total.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp
     }
     if ($Performance.swapRate) {
-        $Performance.swapRate.inRate.start = $Performance.swapRate.inRate.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.swapRate.inRate.end = $Performance.swapRate.inRate.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.swapRate.outRate.start = $Performance.swapRate.outRate.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.swapRate.outRate.end = $Performance.swapRate.outRate.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.swapRate.totalMaxRate.start = $Performance.swapRate.totalMaxRate.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.swapRate.totalMaxRate.end = $Performance.swapRate.totalMaxRate.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.swapRate.totalRate.start = $Performance.swapRate.totalRate.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.swapRate.totalRate.end = $Performance.swapRate.totalRate.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.swapRate.inRate.start = $Performance.swapRate.inRate.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.swapRate.inRate.end = $Performance.swapRate.inRate.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.swapRate.outRate.start = $Performance.swapRate.outRate.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.swapRate.outRate.end = $Performance.swapRate.outRate.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.swapRate.totalMaxRate.start = $Performance.swapRate.totalMaxRate.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.swapRate.totalMaxRate.end = $Performance.swapRate.totalMaxRate.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.swapRate.totalRate.start = $Performance.swapRate.totalRate.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.swapRate.totalRate.end = $Performance.swapRate.totalRate.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
     }
     if ($Performance.throughput) {
-        $Performance.throughput.read.start = $Performance.throughput.read.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.throughput.read.end = $Performance.throughput.read.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.throughput.write.start = $Performance.throughput.write.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.throughput.write.end = $Performance.throughput.write.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.throughput.totalMax.start = $Performance.throughput.totalMax.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.throughput.totalMax.end = $Performance.throughput.totalMax.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.throughput.total.start = $Performance.throughput.total.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.throughput.total.end = $Performance.throughput.total.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.throughput.read.start = $Performance.throughput.read.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.throughput.read.end = $Performance.throughput.read.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.throughput.write.start = $Performance.throughput.write.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.throughput.write.end = $Performance.throughput.write.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.throughput.totalMax.start = $Performance.throughput.totalMax.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.throughput.totalMax.end = $Performance.throughput.totalMax.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.throughput.total.start = $Performance.throughput.total.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.throughput.total.end = $Performance.throughput.total.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
     }
     if ($Performance.writePending.total) {
-        $Performance.writePending.total.start = $Performance.writePending.total.start | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
-        $Performance.writePending.total.end = $Performance.writePending.total.end | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.writePending.total.start = $Performance.writePending.total.start | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
+        $Performance.writePending.total.end = $Performance.writePending.total.end | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone
     }
     if ($Performance.history) {
-        $Performance.history = ParsePerformanceHistory $Performance.history $Timezone
+        $Performance.history = ParsePerformanceHistory -PerformanceHistory $Performance.history -Timezone $Timezone
     }
 
     Write-Output $Performance
@@ -585,12 +585,12 @@ function ParsePerformanceHistory($PerformanceHistory,$Timezone) {
     if ($PerformanceHistory[0].count -eq 2) {
         $PerformanceHistory = foreach ($entry in $PerformanceHistory) {
             if ($entry[1] -replace ' ','') {
-                $entry[1] | Add-Member -MemberType NoteProperty -Name timestamp -Value ($entry[0] | ? { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone) -PassThru
+                $entry[1] | Add-Member -MemberType NoteProperty -Name timestamp -Value ($entry[0] | Where-Object { $_ } | ConvertFrom-UnixTimestamp -Timezone $Timezone) -PassThru
             }
         }
     }
     Write-Output $PerformanceHistory
-} 
+}
 
 function ParseVirtualMachines($VirtualMachines,$Timezone) {
     $VirtualMachines = @($VirtualMachines)
@@ -599,34 +599,35 @@ function ParseVirtualMachines($VirtualMachines,$Timezone) {
             $VirtualMachine.createTime = $VirtualMachine.createTime | Get-Date
         }
         if ($VirtualMachine.performance) {
-            $VirtualMachine.performance = ParsePerformance $VirtualMachine.performance $Timezone
+            $VirtualMachine.performance = ParsePerformance -Performance $VirtualMachine.performance -Timezone $Timezone
         }
         if ($VirtualMachine.vmdks) {
-            $VirtualMachine.vmdks = ParseVmdks($VirtualMachine.vmdks)
+            $VirtualMachine.vmdks = ParseVmdks -Vmdks $VirtualMachine.vmdks
         }
         if ($VirtualMachine.host) {
-            $VirtualMachine.host = ParseHosts($VirtualMachine.host)
+            $VirtualMachine.host = ParseHosts -Hosts $VirtualMachine.host
         }
         if ($VirtualMachine.ports) {
-            $VirtualMachine.ports = ParsePorts $VirtualMachine.ports $Timezone
+            $VirtualMachine.ports = ParsePorts -Ports $VirtualMachine.ports -Timezone $Timezone
         }
         if ($VirtualMachine.dataStore) {
-            $VirtualMachine.dataStore = ParseDatastores $VirtualMachine.dataStore $Timezone
+            $VirtualMachine.dataStore = ParseDatastores -Datastores $VirtualMachine.dataStore -Timezone $Timezone
         }
         if ($VirtualMachine.applications) {
-            $VirtualMachine.applications = ParseApplications $VirtualMachine.applications
+            $VirtualMachine.applications = ParseApplications -Applications $VirtualMachine.applications
         }
-        if ($VirtualMachine.fileSystems) {
-            $VirtualMachine.fileSystems = ParseFileSystems($VirtualMachine.fileSystems)
-        }
+        #TODO: Implement ParseFileSystems function
+        #if ($VirtualMachine.fileSystems) {
+        #    $VirtualMachine.fileSystems = ParseFileSystems -FileSystems $VirtualMachine.fileSystems
+        #}
         if ($VirtualMachine.storageResources) {
-            $VirtualMachine.storageResources = ParseStorageResources($VirtualMachine.storageResources)
+            $VirtualMachine.storageResources = ParseStorageResources -StorageResources $VirtualMachine.storageResources
         }
         if ($VirtualMachine.annotations) {
-            $VirtualMachine.annotations = ParseAnnotations($VirtualMachine.annotations)
+            $VirtualMachine.annotations = ParseAnnotations -Annotations $VirtualMachine.annotations
         }
         if ($VirtualMachine.datasources) {
-            $VirtualMachine.datasources = ParseDatasources($VirtualMachine.datasources)
+            $VirtualMachine.datasources = ParseDatasources -Datasources $VirtualMachine.datasources
         }
 
         Write-Output $VirtualMachine
@@ -637,22 +638,22 @@ function ParseVmdks($Vmdks,$Timezone) {
     $Vmdks = @($Vmdks)
     foreach ($Vmdk in $Vmdks) {
         if ($vmdk.dataStore) {
-            $vmdk.dataStore = ParseDatastores $vmdk.dataStore $Timezone
+            $vmdk.dataStore = ParseDatastores -Datastores $vmdk.dataStore -Timezone $Timezone
         }
         if ($vmdk.virtualMachine) {
-            $vmdk.virtualMachine = ParseVirtualMachines $vmdk.virtualMachine $Timezone
+            $vmdk.virtualMachine = ParseVirtualMachines -VirtualMachines $vmdk.virtualMachine -Timezone $Timezone
         }
         if ($vmdk.performance) {
-            $vmdk.performance = ParsePerformance $vmdk.performance $Timezone
+            $vmdk.performance = ParsePerformance -Performance $vmdk.performance -Timezone $Timezone
         }
         if ($vmdk.storageResources) {
-            $vmdk.storageResources = ParseStorageResources($vmdk.storageResources)
+            $vmdk.storageResources = ParseStorageResources -StorageResources $vmdk.storageResources
         }
         if ($vmdk.annotations) {
-            $vmdk.annotations = ParseAnnotations($vmdk.annotations)
+            $vmdk.annotations = ParseAnnotations -Annotations $vmdk.annotations
         }
         if ($vmdk.datasources) {
-            $vmdk.datasources = ParseDatasources($vmdk.datasources)
+            $vmdk.datasources = ParseDatasources -Datasources $vmdk.datasources
         }
 
         Write-Output $vmdk
@@ -665,31 +666,32 @@ function ParseHosts($Hosts,$Timezone) {
             $HostInstance.createTime = $HostInstance.createTime | Get-Date
         }
         if ($HostInstance.performance) {
-            $HostInstance.performance = ParsePerformance $HostInstance.performance $Timezone
+            $HostInstance.performance = ParsePerformance -Performance $HostInstance.performance -Timezone $Timezone
         }
         if ($HostInstance.storageResources) {
-            $HostInstance.storageResources = ParseStorageResources($HostInstance.storageResources)
+            $HostInstance.storageResources = ParseStorageResources -StorageResources $HostInstance.storageResources
         }
-        if ($HostInstance.fileSystems) {
-            $HostInstance.fileSystems = ParseFileSystems($HostInstance.fileSystems)
-        }
+        #TODO: Implement ParseFileSystems function
+        #if ($HostInstance.fileSystems) {
+        #    $HostInstance.fileSystems = ParseFileSystems -FileSystems $HostInstance.fileSystems
+        #}
         if ($HostInstance.ports) {
-            $HostInstance.ports = ParsePorts $HostInstance.ports $Timezone
+            $HostInstance.ports = ParsePorts -Ports $HostInstance.ports -Timezone $Timezone
         }
         if ($HostInstance.applications) {
-            $HostInstance.applications = ParseApplications($HostInstance.applications)
+            $HostInstance.applications = ParseApplications -Applications $HostInstance.applications
         }
         if ($HostInstance.virtualMachines) {
-            $HostInstance.virtualMachines = ParseVirtualMachines $HostInstance.virtualMachines $Timezone
+            $HostInstance.virtualMachines = ParseVirtualMachines -VirtualMachines $HostInstance.virtualMachines -Timezone $Timezone
         }
         if ($HostInstance.clusterHosts) {
-            $HostInstance.clusterHosts = ParseHosts $HostInstance.clusterHosts $Timezone
+            $HostInstance.clusterHosts = ParseHosts -Hosts $HostInstance.clusterHosts -Timezone $Timezone
         }
         if ($HostInstance.annotations) {
-            $HostInstance.annotations = ParseAnnotations($HostInstance.annotations)
+            $HostInstance.annotations = ParseAnnotations -Annotations $HostInstance.annotations
         }
         if ($HostInstance.datasources) {
-            $HostInstance.datasources = ParseDatasources($HostInstance.datasources)
+            $HostInstance.datasources = ParseDatasources -Datasources $HostInstance.datasources
         }
 
         Write-Output $HostInstance
@@ -699,10 +701,10 @@ function ParseHosts($Hosts,$Timezone) {
 function ParseTopologies($Topologies) {
     foreach ($Topology in $Topologies) {
         if ($Topology.nodes) {
-            $Topology.nodes = ParseTopologyNodes($Topology.nodes)
+            $Topology.nodes = ParseTopologyNodes -Nodes $Topology.nodes
         }
         if ($Topology.links) {
-            $Topology.links = ParseTopologyLinks($Topology.links)
+            $Topology.links = ParseTopologyLinks -Links $Topology.links
         }
 
         Write-Output $Topology
@@ -725,25 +727,25 @@ function ParsePorts($Ports,$Timezone) {
     $Ports = @($Ports)
     foreach ($Port in $Ports) {
         if ($Port.connectedPorts) {
-            $Port.connectedPorts = ParsePorts $Port.connectedPorts $Timezone
+            $Port.connectedPorts = ParsePorts -Ports $Port.connectedPorts -Timezone $Timezone
         }
         if ($Port.performance) {
-            $Port.performance = ParsePerformance $Port.performance $Timezone
+            $Port.performance = ParsePerformance -Performance $Port.performance -Timezone $Timezone
         }
         if ($Port.device) {
-            $Port.device = ParseDevices($Port.device)
+            $Port.device = ParseDevices -Devices $Port.device
         }
         if ($Port.fabrics) {
-            $Port.fabrics = ParseFabrics($Port.fabrics)
+            $Port.fabrics = ParseFabrics -Fabrics $Port.fabrics
         }
         if ($Port.annotations) {
-            $Port.annotations = ParseAnnotations($Port.annotations)
+            $Port.annotations = ParseAnnotations -Annotations $Port.annotations
         }
         if ($Port.datasources) {
-            $Port.datasources = ParseDatasources($Port.datasources)
+            $Port.datasources = ParseDatasources -Datasources $Port.datasources
         }
         if ($Port.application) {
-            $Port.application = ParseApplication($Port.application)
+            $Port.application = ParseApplication -Application $Port.application
         }
 
         Write-Output $Port
@@ -754,22 +756,22 @@ function ParseDevices($Device) {
     $Devices = @($Devices)
     foreach ($Device in $Devices) {
         if ($Device.performance) {
-            $Device.performance = ParsePerformance $Device.performance $Timezone
+            $Device.performance = ParsePerformance -Performance $Device.performance -Timezone $Timezone
         }
         if ($Device.device) {
-            $Device.device = ParseDevice($Device.device)
+            $Device.device = ParseDevice -Device $Device.device
         }
         if ($Device.fabrics) {
-            $Device.fabrics = ParseFabrics($Device.fabrics)
+            $Device.fabrics = ParseFabrics -Fabrics $Device.fabrics
         }
         if ($Device.annotations) {
-            $Device.annotations = ParseAnnotations($Device.annotations)
+            $Device.annotations = ParseAnnotations -Annotations $Device.annotations
         }
         if ($Device.datasources) {
-            $Device.datasources = ParseDatasources($Device.datasources)
+            $Device.datasources = ParseDatasources -Datasources $Device.datasources
         }
         if ($Device.application) {
-            $Device.application = ParseApplication($Device.application)
+            $Device.application = ParseApplication -Application $Device.application
         }
 
         Write-Output $Device
@@ -806,31 +808,32 @@ function ParseComputeResources($ComputeResources,$Timezone) {
             $ComputeResource.createTime = $ComputeResource.createTime | Get-Date
         }
         if ($ComputeResource.performance) {
-            $ComputeResource.performance = ParsePerformance $ComputeResource.performance $Timezone
+            $ComputeResource.performance = ParsePerformance -Performance $ComputeResource.performance -Timezone $Timezone
         }
         if ($ComputeResource.storageResources) {
-            $ComputeResource.storageResources = ParseStorageResources($ComputeResource.storageResources)
+            $ComputeResource.storageResources = ParseStorageResources -StorageResources $ComputeResource.storageResources
         }
-        if ($ComputeResource.fileSystems) {
-            $ComputeResource.fileSystems = ParseFileSystems($ComputeResource.fileSystems)
-        }
+        #TODO: Implement ParseFileSystems function
+        #if ($ComputeResource.fileSystems) {
+        #    $ComputeResource.fileSystems = ParseFileSystems -FileSystems $ComputeResource.fileSystems
+        #}
         if ($ComputeResource.ports) {
-            $ComputeResource.ports = ParsePorts $ComputeResource.ports $Timezone
+            $ComputeResource.ports = ParsePorts -Ports $ComputeResource.ports -Timezone $Timezone
         }
         if ($ComputeResource.applications) {
-            $ComputeResource.applications = ParseApplications($ComputeResource.applications)
+            $ComputeResource.applications = ParseApplications -Applications $ComputeResource.applications
         }
         if ($ComputeResource.virtualMachines) {
-            $ComputeResource.virtualMachines = ParseVirtualMachines $ComputeResource.virtualMachines $Timezone
+            $ComputeResource.virtualMachines = ParseVirtualMachines -VirtualMachines $ComputeResource.virtualMachines -Timezone $Timezone
         }
         if ($ComputeResource.clusterHosts) {
-            $ComputeResource.clusterHosts = ParseHosts($ComputeResource.clusterHosts)
+            $ComputeResource.clusterHosts = ParseHosts -Hosts $ComputeResource.clusterHosts
         }
         if ($ComputeResource.annotations) {
-            $ComputeResource.annotations = ParseAnnotations($ComputeResource.annotations)
+            $ComputeResource.annotations = ParseAnnotations -Annotations $ComputeResource.annotations
         }
         if ($ComputeResource.datasources) {
-            $ComputeResource.datasources = ParseDatasources($ComputeResource.datasources)
+            $ComputeResource.datasources = ParseDatasources -Datasources $ComputeResource.datasources
         }
 
         Write-Output $ComputeResource
@@ -844,28 +847,29 @@ function ParseStorageResources($StorageResources,$Timezone) {
             $StorageResource.createTime = $StorageResource.createTime | Get-Date
         }
         if ($StorageResource.performance) {
-            $StorageResource.performance = ParsePerformance $StorageResource.performance $Timezone
+            $StorageResource.performance = ParsePerformance -Performance $StorageResource.performance -Timezone $Timezone
         }
         if ($StorageResource.computeResources) {
-            $StorageResource.computeResources = ParseComputeResources $StorageResource.computeResources $Timezone
+            $StorageResource.computeResources = ParseComputeResources -ComputeResources $StorageResource.computeResources -Timezone $Timezone
         }
-        if ($StorageResource.fileSystems) {
-            $StorageResource.fileSystems = ParseFileSystems($StorageResource.fileSystems)
-        }
+        #TODO: Implement ParseFileSystems function
+        #if ($StorageResource.fileSystems) {
+        #    $StorageResource.fileSystems = ParseFileSystems -FileSystems $StorageResource.fileSystems
+        #}
         if ($StorageResource.storagePools) {
-            $StorageResource.storagePools = ParseStoragePools($StorageResource.storagePools)
+            $StorageResource.storagePools = ParseStoragePools -StoragePools $StorageResource.storagePools
         }
         if ($StorageResource.applications) {
-            $StorageResource.applications = ParseApplications($StorageResource.applications)
+            $StorageResource.applications = ParseApplications -Applications $StorageResource.applications
         }
         if ($StorageResource.virtualMachines) {
-            $StorageResource.virtualMachines = ParseVirtualMachines $StorageResource.virtualMachines $Timezone
+            $StorageResource.virtualMachines = ParseVirtualMachines -VirtualMachines $StorageResource.virtualMachines -Timezone $Timezone
         }
         if ($StorageResource.annotations) {
-            $StorageResource.annotations = ParseAnnotations($StorageResource.annotations)
+            $StorageResource.annotations = ParseAnnotations -Annotations $StorageResource.annotations
         }
         if ($StorageResource.datasources) {
-            $StorageResource.datasources = ParseDatasources($StorageResource.datasources)
+            $StorageResource.datasources = ParseDatasources -Datasources $StorageResource.datasources
         }
 
         Write-Output $StorageResource
@@ -876,46 +880,46 @@ function ParseVolumes($Volumes,$Timezone) {
     $Volumes = @($Volumes)
     foreach ($Volume in $Volumes) {
         if ($Volume.storage) {
-            $Volume.storage = ParseStorages $Volume.storage $Timezone
+            $Volume.storage = ParseStorages -Storages $Volume.storage -Timezone $Timezone
         }
         if ($Volume.computeResources) {
-            $Volume.computeResources = ParseComputeResources($Volume.computeResources)
+            $Volume.computeResources = ParseComputeResources -ComputeResources $Volume.computeResources
         }
         if ($Volume.storagePool) {
-            $Volume.storagePool = ParseStoragePools($Volume.storagePool)
+            $Volume.storagePool = ParseStoragePools -StoragePools $Volume.storagePool
         }
         if ($Volume.virtualStoragePool) {
-            $Volume.virtualStoragePool = ParseStoragePools($Volume.virtualStoragePool)
+            $Volume.virtualStoragePool = ParseStoragePools -StoragePools $Volume.virtualStoragePool
         }
         if ($Volume.qtrees) {
-            $Volume.qtrees = ParseAnnotations($Volume.qtrees)
+            $Volume.qtrees = ParseAnnotations -Annotations $Volume.qtrees
         }
         if ($Volume.internalVolume) {
-            $Volume.internalVolume = ParseInternalVolumes $Volume.internalVolume $Timezone
+            $Volume.internalVolume = ParseInternalVolumes -InternalVolumes $Volume.internalVolume -Timezone $Timezone
         }
         if ($Volume.dataStores) {
-            $Volume.dataStores = ParseDatastores $Volume.dataStores $Timezone
+            $Volume.dataStores = ParseDatastores -Datastores $Volume.dataStores -Timezone $Timezone
         }
         if ($Volume.annotations) {
-            $Volume.annotations = ParseAnnotations($Volume.annotations)
+            $Volume.annotations = ParseAnnotations -Annotations $Volume.annotations
         }
         if ($Volume.performance) {
-            $Volume.performance = ParsePerformance $Volume.performance $Timezone
+            $Volume.performance = ParsePerformance -Performance $Volume.performance -Timezone $Timezone
         }
         if ($Volume.ports) {
-            $Volume.ports = ParsePorts $Volume.ports $Timezone
+            $Volume.ports = ParsePorts -Ports $Volume.ports -Timezone $Timezone
         }
         if ($Volume.storageNodes) {
-            $Volume.storageNodes = ParseStorageNodes($Volume.storageNodes)
+            $Volume.storageNodes = ParseStorageNodes -StorageNodes $Volume.storageNodes
         }
         if ($Volume.replicaSources) {
-            $Volume.replicaSources = ParseVolumes($Volume.replicaSources)
+            $Volume.replicaSources = ParseVolumes -Volumes $Volume.replicaSources
         }
         if ($Volume.applications) {
-            $Volume.applications = ParseApplications($Volume.applications)
+            $Volume.applications = ParseApplications -Applications $Volume.applications
         }
         if ($Volume.datasources) {
-            $Volume.datasources = ParseDatasources($Volume.datasources)
+            $Volume.datasources = ParseDatasources -Datasources $Volume.datasources
         }
 
         Write-Output $Volume
@@ -926,37 +930,37 @@ function ParseInternalVolumes($InternalVolumes,$Timezone) {
     $InternalVolumes = @($InternalVolumes)
     foreach ($InternalVolume in $InternalVolumes) {
         if ($InternalVolume.storage) {
-            $InternalVolume.storage = ParseStorages $InternalVolume.storage $Timezone
+            $InternalVolume.storage = ParseStorages -Storages $InternalVolume.storage -Timezone $Timezone
         }
         if ($InternalVolume.computeResources) {
-            $InternalVolume.computeResources = ParseComputeResources($InternalVolume.computeResources)
+            $InternalVolume.computeResources = ParseComputeResources -ComputeResources $InternalVolume.computeResources
         }
         if ($InternalVolume.storagePool) {
-            $InternalVolume.storagePool = ParseStoragePools($InternalVolume.storagePool)
+            $InternalVolume.storagePool = ParseStoragePools -StoragePools $InternalVolume.storagePool
         }
         if ($InternalVolume.performance) {
-            $InternalVolume.performance = ParsePerformance $InternalVolume.performance $Timezone
+            $InternalVolume.performance = ParsePerformance -Performance $InternalVolume.performance -Timezone $Timezone
         }
         if ($InternalVolume.volumes) {
-            $InternalVolume.volumes = ParseVolumes($InternalVolume.volumes)
+            $InternalVolume.volumes = ParseVolumes -Volumes $InternalVolume.volumes
         }
         if ($InternalVolume.storageNodes) {
-            $InternalVolume.storageNodes = ParseStorageNodes($InternalVolume.storageNodes)
+            $InternalVolume.storageNodes = ParseStorageNodes -StorageNodes $InternalVolume.storageNodes
         }
         if ($InternalVolume.datasources) {
-            $InternalVolume.datasources = ParseDatasources($InternalVolume.datasources)
+            $InternalVolume.datasources = ParseDatasources -Datasources $InternalVolume.datasources
         }
         if ($InternalVolume.datastores) {
-            $InternalVolume.datastores = ParseDatastores $InternalVolume.datastores $Timezone
+            $InternalVolume.datastores = ParseDatastores -Datastores $InternalVolume.datastores -Timezone $Timezone
         }
         if ($InternalVolume.applications) {
-            $InternalVolume.applications = ParseApplications($InternalVolume.applications)
+            $InternalVolume.applications = ParseApplications -Applications $InternalVolume.applications
         }
         if ($InternalVolume.annotations) {
-            $InternalVolume.annotations = ParseAnnotations($InternalVolume.annotations)
+            $InternalVolume.annotations = ParseAnnotations -Annotations $InternalVolume.annotations
         }
         if ($InternalVolume.qtrees) {
-            $InternalVolume.qtrees = ParseAnnotations($InternalVolume.qtrees)
+            $InternalVolume.qtrees = ParseAnnotations -Annotations $InternalVolume.qtrees
         }
 
         Write-Output $InternalVolume
@@ -967,25 +971,25 @@ function ParseQtrees($Qtrees) {
     $Qtrees = @($Qtrees)
     foreach ($Qtree in $Qtrees) {
         if ($Qtree.quotaCapacity) {
-            $Qtree.quotaCapacity = ParseQuotaCapacities($Qtree.quotaCapacity)
+            $Qtree.quotaCapacity = ParseQuotaCapacities -QuotaCapacities $Qtree.quotaCapacity
         }
         if ($Qtree.storage) {
-            $Qtree.storage = ParseStorages $Qtree.storage $Timezone
+            $Qtree.storage = ParseStorages -Storages $Qtree.storage -Timezone $Timezone
         }
         if ($Qtree.internalVolume) {
-            $Qtree.internalVolume = ParseInternalVolumes $Qtree.internalVolume $Timezone
+            $Qtree.internalVolume = ParseInternalVolumes -InternalVolumes $Qtree.internalVolume -Timezone $Timezone
         }
         if ($Qtree.shares) {
-            $Qtree.shares = ParseShares($Qtree.shares)
+            $Qtree.shares = ParseShares -Shares $Qtree.shares
         }
         if ($Qtree.annotations) {
-            $Qtree.annotations = ParseAnnotations($Qtree.annotations)
+            $Qtree.annotations = ParseAnnotations -Annotations $Qtree.annotations
         }
         if ($Qtree.applications) {
-            $Qtree.applications = ParseApplications($Qtree.applications)
+            $Qtree.applications = ParseApplications -Applications $Qtree.applications
         }
         if ($Qtree.volumes) {
-            $Qtree.volumes = ParseVolumes($Qtree.volumes)
+            $Qtree.volumes = ParseVolumes -Volumes $Qtree.volumes
         }
 
         Write-Output $Qtree
@@ -999,7 +1003,7 @@ function ParseQuotaCapacities($QuotaCapacities) {
     }
 }
 
-function ParseShares($Qtrees) {
+function ParseShares($Shares) {
     $Shares = @($Shares)
     foreach ($Share in $Shares) {
         Write-Output $Share
@@ -1010,31 +1014,31 @@ function ParseStoragePools($StoragePools) {
     $StoragePools = @($StoragePools)
     foreach ($StoragePool in $StoragePools) {
         if ($StoragePool.performance) {
-            $StoragePool.performance = ParsePerformance $StoragePool.performance $Timezone
+            $StoragePool.performance = ParsePerformance -Performance $StoragePool.performance -Timezone $Timezone
         }
         if ($StoragePool.storage) {
-            $StoragePool.storage = ParseStorages $StoragePool.storage $Timezone
+            $StoragePool.storage = ParseStorages -Storages $StoragePool.storage -Timezone $Timezone
         }
         if ($StoragePool.disks) {
-            $StoragePool.disks = ParseDisks($StoragePool.disks)
+            $StoragePool.disks = ParseDisks -Disks $StoragePool.disks
         }
         if ($StoragePool.storageResources) {
-            $StoragePool.storageResources = ParseStorageResources($StoragePool.storageResources)
+            $StoragePool.storageResources = ParseStorageResources -StorageResources $StoragePool.storageResources
         }
         if ($StoragePool.internalVolumes) {
-            $StoragePool.internalVolumes = ParseInternalVolumes $StoragePool.internalVolumes $Timezone
+            $StoragePool.internalVolumes = ParseInternalVolumes -InternalVolumes $StoragePool.internalVolumes -Timezone $Timezone
         }
         if ($StoragePool.volumes) {
-            $StoragePool.volumes = ParseVolumes($StoragePool.volumes)
+            $StoragePool.volumes = ParseVolumes -Volumes $StoragePool.volumes
         }
         if ($StoragePool.storageNodes) {
-            $StoragePool.storageNodes = ParseStorageNodes($StoragePool.storageNodes)
+            $StoragePool.storageNodes = ParseStorageNodes -StorageNodes $StoragePool.storageNodes
         }
         if ($StoragePool.datasources) {
-            $StoragePool.datasources = ParseDatasources($StoragePool.datasources)
+            $StoragePool.datasources = ParseDatasources -Datasources $StoragePool.datasources
         }
         if ($StoragePool.annotations) {
-            $StoragePool.annotations = ParseAnnotations($StoragePool.annotations)
+            $StoragePool.annotations = ParseAnnotations -Annotations $StoragePool.annotations
         }
 
         Write-Output $StoragePool
@@ -1048,43 +1052,43 @@ function ParseStorages($Storages, $Timezone) {
             $Storage.createTime = $Storage.createTime | Get-Date
         }
         if ($Storage.storageNodes) {
-            $Storage.storageNodes = ParseStorageNodes($Storage.storageNodes)
+            $Storage.storageNodes = ParseStorageNodes -StorageNodes $Storage.storageNodes
         }
         if ($Storage.storagePools) {
-            $Storage.storagePools = ParseStoragePools($Storage.storagePools)
+            $Storage.storagePools = ParseStoragePools -StoragePools $Storage.storagePools
         }
         if ($Storage.storageResources) {
-            $Storage.storageResources = ParseStorageResources($Storage.storageResources)
+            $Storage.storageResources = ParseStorageResources -StorageResources $Storage.storageResources
         }
         if ($Storage.internalVolumes) {
-            $Storage.internalVolumes = ParseInternalVolumes $Storage.internalVolumes $Timezone
+            $Storage.internalVolumes = ParseInternalVolumes -InternalVolumes $Storage.internalVolumes -Timezone $Timezone
         }
         if ($Storage.volumes) {
-            $Storage.volumes = ParseVolumes($Storage.volumes)
+            $Storage.volumes = ParseVolumes -Volumes $Storage.volumes
         }
         if ($Storage.disks) {
-            $Storage.disks = ParseDisks($Storage.disks)
+            $Storage.disks = ParseDisks -Disks $Storage.disks
         }
         if ($Storage.datasources) {
-            $Storage.datasources = ParseDatasources($Storage.datasources)
+            $Storage.datasources = ParseDatasources -Datasources $Storage.datasources
         }
         if ($Storage.ports) {
-            $Storage.ports = ParsePorts $Storage.ports $Timezone
+            $Storage.ports = ParsePorts -Ports $Storage.ports -Timezone $Timezone
         }
         if ($Storage.annotations) {
-            $Storage.annotations = ParseAnnotations($Storage.annotations)
+            $Storage.annotations = ParseAnnotations -Annotations $Storage.annotations
         }
         if ($Storage.qtrees) {
-            $Storage.qtrees = ParseQtrees($Storage.qtrees)
+            $Storage.qtrees = ParseQtrees -Qtrees $Storage.qtrees
         }
         if ($Storage.shares) {
-            $Storage.shares = ParseShares($Storage.shares)
+            $Storage.shares = ParseShares -Shares $Storage.shares
         }
         if ($Storage.applications) {
-            $Storage.applications = ParseApplications($Storage.applications)
+            $Storage.applications = ParseApplications -Applications $Storage.applications
         }
         if ($Storage.performance) {
-            $Storage.performance = ParsePerformance $Storage.performance $Timezone
+            $Storage.performance = ParsePerformance -Performance $Storage.performance -Timezone $Timezone
         }
 
         Write-Output $Storage
@@ -1095,7 +1099,7 @@ function ParseStorageNodes($StorageNodes) {
     $StorageNodes = @($StorageNodes)
     foreach ($StorageNode in $StorageNodes) {
         if ($StorageNode.performance) {
-            $StorageNode.performance = ParsePerformance $StorageNode.performance $Timezone
+            $StorageNode.performance = ParsePerformance -Performance $StorageNode.performance -Timezone $Timezone
         }
 
         Write-Output $StorageNode
@@ -1106,22 +1110,22 @@ function ParseDisks($Disks) {
     $Disks = @($Disks)
     foreach ($Disk in $Disks) {
         if ($Disk.performance) {
-            $Disk.performance = ParsePerformance $Disk.performance $Timezone
+            $Disk.performance = ParsePerformance -Performance $Disk.performance -Timezone $Timezone
         }
         if ($Disk.storage) {
-            $Disk.storage = ParseStorages $Disk.storage $Timezone
+            $Disk.storage = ParseStorages -Storages $Disk.storage -Timezone $Timezone
         }
         if ($Disk.storageResources) {
-            $Disk.storageResources = ParseStorageResources($Disk.storageResources)
+            $Disk.storageResources = ParseStorageResources -StorageResources $Disk.storageResources
         }
         if ($Disk.backendVolumes) {
-            $Disk.backendVolumes = ParseVolumes($Disk.backendVolumes)
+            $Disk.backendVolumes = ParseVolumes -Volumes $Disk.backendVolumes
         }
         if ($Disk.datasources) {
-            $Disk.datasources = ParseDatasources($Disk.datasources)
+            $Disk.datasources = ParseDatasources -Datasources $Disk.datasources
         }
         if ($Disk.annotations) {
-            $Disk.annotations = ParseAnnotations($Disk.annotations)
+            $Disk.annotations = ParseAnnotations -Annotations $Disk.annotations
         }
 
         Write-Output $Disk
@@ -1132,10 +1136,10 @@ function ParseFabrics($Fabrics) {
     $Fabrics = @($Fabrics)
     foreach ($Fabric in $Fabrics) {
         if ($Fabric.datasources) {
-            $Fabric.datasources = ParseDatasources($Fabric.datasources)
+            $Fabric.datasources = ParseDatasources -Datasources $Fabric.datasources
         }
         if ($Fabric.switches) {
-            $Fabric.switches = ParseDatasources($Fabric.switches)
+            $Fabric.switches = ParseDatasources -Datasources $Fabric.switches
         }
 
         Write-Output $Fabric
@@ -1171,20 +1175,20 @@ function ParsePatchStatus($PatchStatus) {
 #>
 function Global:Get-OciMetadata {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                    Position=0,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/uiserver/webui/v1/metadata"
 
@@ -1192,12 +1196,12 @@ function Global:Get-OciMetadata {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim
         }
 
         # TODO: Implement parsing
@@ -1219,7 +1223,7 @@ Timezone   : (UTC+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna
 #>
 function global:Connect-OciServer {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                    Position=0,
@@ -1246,11 +1250,11 @@ function global:Connect-OciServer {
                    Position=6,
                    HelpMessage="Timeout value for HTTP connections. Defaults to 600 seconds.")][Int]$Timeout
     )
- 
+
     $EncodedAuthorization = [System.Text.Encoding]::UTF8.GetBytes($Credential.UserName + ':' + $Credential.GetNetworkCredential().Password)
     $EncodedPassword = [System.Convert]::ToBase64String($EncodedAuthorization)
     $Headers = @{"Authorization"="Basic $($EncodedPassword)"}
- 
+
     # check if untrusted SSL certificates should be ignored
     if ($Insecure) {
         if ($PSVersionTable.PSVersion.Major -lt 6) {
@@ -1281,7 +1285,7 @@ function global:Connect-OciServer {
         }
     }
     catch {}
- 
+
     if ($HTTPS -or !$HTTP) {
         Try {
             $BaseURI = "https://$Name"
@@ -1289,7 +1293,7 @@ function global:Connect-OciServer {
             $APIVersion = [System.Version]$Response.apiVersion
         }
         Catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             if ($_.Exception.Message -match "Unauthorized") {
                 Write-Error "Authorization for $BaseURI/rest/v1/login with user $($Credential.UserName) failed"
                 return
@@ -1314,8 +1318,8 @@ function global:Connect-OciServer {
             $APIVersion = [System.Version]$Response.apiVersion
         }
         Catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
-            if ($_.Exception.Message -match "Unauthorized") {                
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
+            if ($_.Exception.Message -match "Unauthorized") {
                 Write-Error "Authorization for $BaseURI/rest/v1/login with user $($Credential.UserName) failed"
                 return
             }
@@ -1329,10 +1333,10 @@ function global:Connect-OciServer {
     if (!$Timezone) {
         $Timezone = [System.TimeZoneInfo]::Local
     }
-    
+
     if ($Timezone -isnot [System.TimeZoneInfo]) {
         if ([System.TimeZoneInfo]::GetSystemTimeZones().Id -contains $Timezone) {
-            $Timezone = [System.TimeZoneInfo]::GetSystemTimeZones() | ? { $_.Id -contains $Timezone }
+            $Timezone = [System.TimeZoneInfo]::GetSystemTimeZones() | Where-Object { $_.Id -contains $Timezone }
         }
         else {
             Write-Warning "Timezone $Timezone is not supported by this system. Setting Timezone to $([System.TimeZoneInfo]::Local)"
@@ -1343,7 +1347,7 @@ function global:Connect-OciServer {
     if (!$Timeout) {
         $Timeout = 600
     }
- 
+
     $Server = [PSCustomObject]@{Name=$Name;
                             BaseURI=$BaseURI;
                             Credential=$Credential;
@@ -1352,11 +1356,11 @@ function global:Connect-OciServer {
                             Timezone=$Timezone;
                             Timeout=$Timeout;
                             Session=$Session}
- 
+
     if (!$Transient) {
         Set-Variable -Name CurrentOciServer -Value $Server -Scope Global
     }
- 
+
     return $Server
 }
 
@@ -1376,7 +1380,7 @@ function global:Connect-OciServer {
 #>
 function global:Import-OciServerCertificate {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                    Position=0,
@@ -1404,7 +1408,7 @@ function global:Import-OciServerCertificate {
             throw "Administrator privilige required to store certificate in LocalMachine certificate store"
         }
     }
-   
+
     Process {
         $Request = [Net.HttpWebRequest]::Create($Uri)
         $Request.Method = "OPTIONS"
@@ -1414,7 +1418,7 @@ function global:Import-OciServerCertificate {
         }
         catch {
         }
- 
+
         if (!$Request.ServicePoint.Certificate) {
             Write-Error "No Certificate returned for $Uri"
         }
@@ -1456,7 +1460,7 @@ function global:Import-OciServerCertificate {
 #>
 function global:Remove-OciServerCertificate {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                    Position=0,
@@ -1484,7 +1488,7 @@ function global:Remove-OciServerCertificate {
             throw "Administrator privilige required to remove certificate from LocalMachine certificate store"
         }
     }
-   
+
     Process {
         $Request = [Net.HttpWebRequest]::Create($Uri)
         $Request.Method = "OPTIONS"
@@ -1494,7 +1498,7 @@ function global:Remove-OciServerCertificate {
         }
         catch {
         }
- 
+
         if (!$Request.ServicePoint.Certificate) {
             Write-Error "No Certificate returned for $Uri"
         }
@@ -1536,7 +1540,7 @@ function global:Remove-OciServerCertificate {
 #>
 function Global:Get-OciAcquisitionUnits {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                     Position=0,
@@ -1548,7 +1552,7 @@ function Global:Get-OciAcquisitionUnits {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -1567,7 +1571,7 @@ function Global:Get-OciAcquisitionUnits {
             }
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/admin/acquisitionUnits"
 
@@ -1579,15 +1583,15 @@ function Global:Get-OciAcquisitionUnits {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim
         }
 
-        $AcquisitionUnits = ParseAcquisitionUnits($Result)
+        $AcquisitionUnits = ParseAcquisitionUnits -AcquisitionUnits $Result
         Write-Output $AcquisitionUnits
     }
 }
@@ -1608,7 +1612,7 @@ function Global:Get-OciAcquisitionUnits {
 #>
 function Global:Get-OciAcquisitionUnit {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -1625,7 +1629,7 @@ function Global:Get-OciAcquisitionUnit {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -1644,29 +1648,29 @@ function Global:Get-OciAcquisitionUnit {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $($Server.BaseUri) + "/rest/v1/admin/acquisitionUnits/$id"            
- 
+            $Uri = $($Server.BaseUri) + "/rest/v1/admin/acquisitionUnits/$id"
+
             if ($expand) {
                 $Uri += "?expand=$expand"
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim
             }
 
-            $AcquisitionUnit = ParseAcquisitionUnits($Result)
+            $AcquisitionUnit = ParseAcquisitionUnits -AcquisitionUnits $Result
             Write-Output $AcquisitionUnit
         }
     }
@@ -1702,7 +1706,7 @@ function Global:Get-OciAcquisitionUnit {
 #>
 function Global:Get-OciDatasourcesByAcquisitionUnit {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -1740,7 +1744,7 @@ function Global:Get-OciDatasourcesByAcquisitionUnit {
                    Position=10,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -1759,29 +1763,29 @@ function Global:Get-OciDatasourcesByAcquisitionUnit {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/admin/acquisitionUnits/$id/datasources"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/admin/acquisitionUnits/$id/datasources"
+
             if ($expand) {
                 $Uri += "?$($Separator)expand=$expand"
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim
             }
 
-            $Datasources = ParseDatasources($Result)
+            $Datasources = ParseDatasources -Datasources $Result
             Write-Output $Datasources
         }
     }
@@ -1799,7 +1803,7 @@ function Global:Get-OciDatasourcesByAcquisitionUnit {
 #>
 function Global:Restart-OciAcquisitionUnit {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -1810,32 +1814,32 @@ function Global:Restart-OciAcquisitionUnit {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/admin/acquisitionUnits/$id/restart"
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method POST -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "POST to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim
             }
-       
-            $AcquisitionUnit = ParseAcquisitionUnits($Result)
+
+            $AcquisitionUnit = ParseAcquisitionUnits -AcquisitionUnits $Result
             Write-Output $AcquisitionUnit
         }
     }
@@ -1853,38 +1857,38 @@ function Global:Restart-OciAcquisitionUnit {
 #>
 function Global:Get-OciCertificates {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                    Position=0,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/admin/certificates"
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim
             }
-       
-            $Certificates = ParseCertificates($Result)
+
+            $Certificates = ParseCertificates -Certificates $Result
             Write-Output $Certificates
         }
     }
@@ -1915,7 +1919,7 @@ To create from existing certificate file create a multi part request with the at
 #>
 function Global:Add-OciCertificate {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                    Position=0,
@@ -1937,34 +1941,34 @@ function Global:Add-OciCertificate {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/admin/certificates"
- 
+
             try {
                 $Body = ConvertTo-Json @{"host"=$HostName;"port"=$Port} -Compress
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method POST -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "POST to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim
             }
-       
-            $Certificate = ParseCertificate($Result)
+
+            $Certificate = ParseCertificate -Certificate $Result
             Write-Output $Certificate
         }
     }
@@ -1982,36 +1986,36 @@ function Global:Add-OciCertificate {
 #>
 function Global:Get-OciDatasourceTypes {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                    Position=0,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/admin/datasourceTypes"
- 
+
         try {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim
         }
-       
-        $DatasourceTypes = ParseDatasourceTypes($Result)
+
+        $DatasourceTypes = ParseDatasourceTypes -DatasourceTypes $Result
         Write-Output $DatasourceTypes
     }
 }
@@ -2028,7 +2032,7 @@ function Global:Get-OciDatasourceTypes {
 #>
 function Global:Get-OciDatasourceType {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                    Position=0,
@@ -2039,32 +2043,32 @@ function Global:Get-OciDatasourceType {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/admin/datasourceTypes/$id"      
- 
+            $Uri = $Server.BaseUri + "/rest/v1/admin/datasourceTypes/$id"
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim
             }
-           
-            $DatasourceType = ParseDatasourceTypes($Result)
+
+            $DatasourceType = ParseDatasourceTypes -DatasourceTypes $Result
             Write-Output $DatasourceType
         }
     }
@@ -2098,7 +2102,7 @@ function Global:Get-OciDatasourceType {
 #>
 function Global:Get-OciDatasources {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                     Position=0,
@@ -2131,7 +2135,7 @@ function Global:Get-OciDatasources {
                    Position=9,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -2150,29 +2154,29 @@ function Global:Get-OciDatasources {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/admin/datasources"
- 
+
             if ($expand) {
                 $Uri += "?$($Separator)expand=$expand"
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim
             }
-           
-            $Datasources = ParseDatasources($Result)
+
+            $Datasources = ParseDatasources -Datasources $Result
             Write-Output $Datasources
         }
     }
@@ -2182,9 +2186,9 @@ function Global:Get-OciDatasources {
     .SYNOPSIS
     New Data Source
     .DESCRIPTION
-    Create new Data Source from type definition  
+    Create new Data Source from type definition
     .PARAMETER type
-    Datasource type 
+    Datasource type
     .PARAMETER name
     Name of the datasource
     .PARAMETER acquisitionUnit
@@ -2194,7 +2198,7 @@ function Global:Get-OciDatasources {
 #>
 function Global:New-OciDatasource {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -2209,18 +2213,18 @@ function Global:New-OciDatasource {
                     HelpMessage="Datasource acquisition unit",
                     ValueFromPipelineByPropertyName=$True)][PSObject]$acquisitionUnit
     )
-   
+
     Process {
-        
+
         $Datasource = [PSCustomObject]@{name=$Name;acquisitionUnit=[PSCustomObject]@{}}
 
         $Datasource | Add-Member -MemberType NoteProperty -Name "config" -Value ([PSCustomObject]@{})
-        
+
         if ($acquisitionUnit -is [int]) {
             $Datasource.acquisitionUnit | Add-Member -MemberType NoteProperty -Name "id" -value $acquisitionUnit
         }
         elseif ($acquisitionUnit.id) {
-            $Datasource.acquisitionUnit = $acquisitionUnit | select -property id
+            $Datasource.acquisitionUnit = $acquisitionUnit | Select-Object -Property id
         }
 
         $Datasource.config | Add-Member -MemberType NoteProperty -Name "dsTypeId" -Value $type.id
@@ -2230,7 +2234,7 @@ function Global:New-OciDatasource {
 
         # if no packages are specified, enable all packages of specified type
         if ($packages) {
-            $type.packages = $type.packages | ? { $packages -match $_.id }
+            $type.packages = $type.packages | Where-Object { $packages -match $_.id }
         }
 
         foreach ($package in $type.packages) {
@@ -2242,8 +2246,8 @@ function Global:New-OciDatasource {
             $Datasource.config.packages += $package
         }
 
-        # parse datasource to make sure that script properties are created 
-        $Datasource = ParseDatasources($Datasource)
+        # parse datasource to make sure that script properties are created
+        $Datasource = ParseDatasources -Datasources $Datasource
         Write-Output $Datasource
     }
 }
@@ -2252,7 +2256,7 @@ function Global:New-OciDatasource {
     .SYNOPSIS
     Add Data Source
     .DESCRIPTION
-    Add Data Source    
+    Add Data Source
     .PARAMETER name
     Datasource name
     .PARAMETER acquisitionUnit
@@ -2264,7 +2268,7 @@ function Global:New-OciDatasource {
 #>
 function Global:Add-OciDatasource {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -2282,48 +2286,48 @@ function Global:Add-OciDatasource {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/admin/datasources"
- 
+
         try {
             $Body = @{}
-            if ($Name) { 
-                $Body.name = $Name 
+            if ($Name) {
+                $Body.name = $Name
             }
             if ($acquisitionUnit) {
                 if ($acquisitionUnit -is [int]) {
                     $Body.acquisitionUnit = @{id=$acquisitionUnit}
                 }
                 elseif ($acquisitionUnit.id) {
-                    $Body.acquisitionUnit = $acquisitionUnit | select -property id
+                    $Body.acquisitionUnit = $acquisitionUnit | Select-Object -Property id
                 }
             }
             if ($config) {
-                $ConfigScriptProperties = $config.PSObject.Members | ? { $_.MemberType -eq "ScriptProperty" } | % { $_.Name }
-                $Body.config = $config | Select -Property * -ExcludeProperty $ConfigScriptProperties
+                $ConfigScriptProperties = $config.PSObject.Members | Where-Object { $_.MemberType -eq "ScriptProperty" } | ForEach-Object { $_.Name }
+                $Body.config = $config | Select-Object -Property * -ExcludeProperty $ConfigScriptProperties
                 $Uri += "?expand=config"
             }
             $Body = $Body | ConvertTo-Json -Depth 10
             Write-Verbose "Body: $Body"
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method POST -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             if ($Result.toString().startsWith('{')) {
-                $Result = ParseJsonString($Result)
+                $Result = ParseJsonString -json $Result
             }
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "POST to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
-       
-        $Datasource = ParseDatasources($Result)
+
+        $Datasource = ParseDatasources -Datasources $Result
         Write-Output $Datasource
     }
 }
@@ -2356,7 +2360,7 @@ function Global:Add-OciDatasource {
 #>
 function Global:Remove-OciDatasource {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -2367,32 +2371,32 @@ function Global:Remove-OciDatasource {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/admin/datasources/$id"
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim
             }
-           
-            $Datasource = ParseDatasources($Result)
+
+            $Datasource = ParseDatasources -Datasources $Result
             Write-Output $Datasource
         }
     }
@@ -2428,7 +2432,7 @@ function Global:Remove-OciDatasource {
 #>
 function Global:Get-OciDatasource {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -2466,7 +2470,7 @@ function Global:Get-OciDatasource {
                    Position=10,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -2485,29 +2489,29 @@ function Global:Get-OciDatasource {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/admin/datasources/$id"
- 
+
             if ($expand) {
                 $Uri += "?$($Separator)expand=$expand"
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim
             }
-       
-            $Datasource = ParseDatasources($Result)
+
+            $Datasource = ParseDatasources -Datasources $Result
             Write-Output $Datasource
         }
     }
@@ -2531,7 +2535,7 @@ function Global:Get-OciDatasource {
 #>
 function Global:Update-OciDataSource {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -2553,49 +2557,49 @@ function Global:Update-OciDataSource {
                    Position=4,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/admin/datasources/$id"
- 
+
         try {
             $Body = @{}
-            if ($Name) { 
-                $Body.name = $Name 
+            if ($Name) {
+                $Body.name = $Name
             }
-            if ($acquisitionUnit) { 
-                $Body.acquisitionUnit = $acquisitionUnit | select -property id
+            if ($acquisitionUnit) {
+                $Body.acquisitionUnit = $acquisitionUnit | Select-Object -Property id
             }
             if ($config) {
-                $ConfigScriptProperties = $config.PSObject.Members | ? { $_.MemberType -eq "ScriptProperty" } | % { $_.Name }
+                $ConfigScriptProperties = $config.PSObject.Members | Where-Object { $_.MemberType -eq "ScriptProperty" } | ForEach-Object { $_.Name }
                 if (!$config.foundation.attributes.password) {
                     $config.foundation.attributes.PSObject.Properties.Remove('password')
                 }
                 if (!$config.foundation.attributes.'partner.password') {
                     $config.foundation.attributes.PSObject.Properties.Remove('partner.password')
                 }
-                $Body.config = $config | Select -Property * -ExcludeProperty $ConfigScriptProperties
+                $Body.config = $config | Select-Object -Property * -ExcludeProperty $ConfigScriptProperties
                 $Uri += "?expand=config"
             }
             $Body = $Body | ConvertTo-Json -Depth 10
             Write-Verbose "Body: $Body"
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PATCH -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             if ($Result.toString().startsWith('{')) {
-                $Result = ParseJsonString($Result)
+                $Result = ParseJsonString -json $Result
             }
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "PATCH to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
-       
-        $Datasource = ParseDatasources($Result)
+
+        $Datasource = ParseDatasources -Datasources $Result
         if ($Datasource.config.packages) {
             $config.packages = $Datasource.config.packages
         }
@@ -2619,7 +2623,7 @@ function Global:Update-OciDataSource {
 #>
 function Global:Get-OciAcquisitionUnitByDatasource {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -2636,7 +2640,7 @@ function Global:Get-OciAcquisitionUnitByDatasource {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -2655,30 +2659,30 @@ function Global:Get-OciAcquisitionUnitByDatasource {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $($Server.BaseUri) + "/rest/v1/admin/datasources/$id/acquisitionUnit"
- 
+
             if ($expand) {
                 $Uri += "?$($Separator)expand=$expand"
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim
             }
 
-            $AcquisitionUnit = ParseAcquisitionUnits($Result)
-           
+            $AcquisitionUnit = ParseAcquisitionUnits -AcquisitionUnits $Result
+
             Write-Output $AcquisitionUnit
         }
     }
@@ -2700,7 +2704,7 @@ function Global:Get-OciAcquisitionUnitByDatasource {
 #>
 function Global:Get-OciActivePatchByDatasource {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -2717,7 +2721,7 @@ function Global:Get-OciActivePatchByDatasource {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -2736,29 +2740,29 @@ function Global:Get-OciActivePatchByDatasource {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/admin/datasources/$id/activePatch"
- 
+
             if ($expand) {
                 $Uri += "?$($Separator)expand=$expand"
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim
             }
-           
-            $ActivePatch = ParseActivePatches($Result)
+
+            $ActivePatch = ParseActivePatches -ActivePatches $Result
             Write-Output $ActivePatch
         }
     }
@@ -2780,7 +2784,7 @@ function Global:Get-OciActivePatchByDatasource {
 #>
 function Global:Get-OciDatasourceChanges {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -2797,7 +2801,7 @@ function Global:Get-OciDatasourceChanges {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -2816,7 +2820,7 @@ function Global:Get-OciDatasourceChanges {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
@@ -2825,20 +2829,20 @@ function Global:Get-OciDatasourceChanges {
             if ($expand) {
                 $Uri += "?$($Separator)expand=$expand"
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim
             }
-           
-            $Change = ParseChanges($Result)
+
+            $Change = ParseChanges -Changes $Result
             Write-Output $Change
         }
     }
@@ -2856,7 +2860,7 @@ function Global:Get-OciDatasourceChanges {
 #>
 function Global:Get-OciDatasourceConfiguration {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -2867,32 +2871,32 @@ function Global:Get-OciDatasourceConfiguration {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/admin/datasources/$id/config"
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-            
-            $DatasourceConfiguration = ParseDatasourceConfig($Result)
+
+            $DatasourceConfiguration = ParseDatasourceConfig -DatasourceConfig $Result
             Write-Output $DatasourceConfiguration
         }
     }
@@ -2910,7 +2914,7 @@ function Global:Get-OciDatasourceConfiguration {
 #>
 function Global:Get-OciDatasourceDevices {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -2921,31 +2925,31 @@ function Global:Get-OciDatasourceDevices {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/admin/datasources/$id/devices"
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -2965,7 +2969,7 @@ function Global:Get-OciDatasourceDevices {
 #>
 function Global:Get-OciDatasourceEvents {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -2979,7 +2983,7 @@ function Global:Get-OciDatasourceEvents {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -2998,28 +3002,28 @@ function Global:Get-OciDatasourceEvents {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/admin/datasources/$id/events"
- 
+
             if ($expand) {
                 $Uri += "?$($Separator)expand=$expand"
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -3037,7 +3041,7 @@ function Global:Get-OciDatasourceEvents {
 #>
 function Global:Get-OciDatasourceEventDetails {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -3048,32 +3052,32 @@ function Global:Get-OciDatasourceEventDetails {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/admin/datasources/events/$id/details"
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-          
-            $Events = ParseEvents($Result)
+
+            $Events = ParseEvents -Events $Result
             Write-Output $Events
         }
     }
@@ -3091,7 +3095,7 @@ function Global:Get-OciDatasourceEventDetails {
 #>
 function Global:Get-OciDatasourceNote {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -3102,31 +3106,31 @@ function Global:Get-OciDatasourceNote {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/admin/datasources/$id/note"
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-          
+
             Write-Output $Result
         }
     }
@@ -3146,7 +3150,7 @@ function Global:Get-OciDatasourceNote {
 #>
 function Global:Update-OciDatasourceNote {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -3160,31 +3164,31 @@ function Global:Update-OciDatasourceNote {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/admin/datasources/$id/note"
- 
+
         try {
             $Body = @{value=$value} | ConvertTo-Json -Compress
             Write-Verbose "Body: $Body"
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PUT -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "PUT to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-           
+
         Write-Output $Result
     }
 }
@@ -3201,7 +3205,7 @@ function Global:Update-OciDatasourceNote {
 #>
 function Global:Get-OciDatasourcePackageStatus {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -3212,31 +3216,31 @@ function Global:Get-OciDatasourcePackageStatus {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/admin/datasources/$id/packages"
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-          
+
             Write-Output $Result
         }
     }
@@ -3254,7 +3258,7 @@ function Global:Get-OciDatasourcePackageStatus {
 #>
 function Global:Poll-OciDatasource {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -3265,31 +3269,31 @@ function Global:Poll-OciDatasource {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/admin/datasources/$id/poll"
- 
+
         try {
             $Body = ""
             Write-Verbose "Body: $Body"
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method POST -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "POST to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-           
+
         Write-Output $Result
     }
 }
@@ -3308,7 +3312,7 @@ function Global:Poll-OciDatasource {
 #>
 function Global:Suspend-OciDatasource {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -3322,31 +3326,31 @@ function Global:Suspend-OciDatasource {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/admin/datasources/$id/postpone"
- 
+
         try {
             $Body = @{days=$days} | ConvertTo-Json -Compress
             Write-Verbose "Body: $Body"
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method POST -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "POST to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-           
+
         Write-Output $Result
     }
 }
@@ -3361,7 +3365,7 @@ function Global:Suspend-OciDatasource {
 #>
 function Global:Resume-OciDatasource {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -3372,17 +3376,17 @@ function Global:Resume-OciDatasource {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
-        $Uri = $Server.BaseUri + "/rest/v1/admin/datasources/$id/resume"         
- 
+        $Uri = $Server.BaseUri + "/rest/v1/admin/datasources/$id/resume"
+
         if ($fromTime -or $toTime -or $expand) {
             $Uri += '?'
             $Separator = ''
@@ -3398,7 +3402,7 @@ function Global:Resume-OciDatasource {
                 $Uri += "$($Separator)expand=$expand"
             }
         }
- 
+
         try {
             if ('POST' -match 'PUT|POST') {
                 Write-Verbose "Body: "
@@ -3409,14 +3413,14 @@ function Global:Resume-OciDatasource {
             }
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "POST to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-           
+
         Write-Output $Result
     }
 }
@@ -3433,7 +3437,7 @@ function Global:Resume-OciDatasource {
 #>
 function Global:Test-OciDatasource {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                    Position=0,
@@ -3444,31 +3448,31 @@ function Global:Test-OciDatasource {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
-        $Uri = $Server.BaseUri + "/rest/v1/admin/datasources/$id/test"            
- 
+        $Uri = $Server.BaseUri + "/rest/v1/admin/datasources/$id/test"
+
         try {
             $Body = ""
             Write-Verbose "Body: $Body"
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method POST -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "POST to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-           
+
         Write-Output $Result
     }
 }
@@ -3485,35 +3489,35 @@ function Global:Test-OciDatasource {
 #>
 function Global:Get-OciLdapConfiguration {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                    Position=0,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/admin/ldap"
- 
+
         try {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-        
+
         # add empty password to directoryLookup as this is not returned from OCI Server and is required for passing object to Update-OciLdapConfiguration
         $Result.directoryLookup | Add-Member -MemberType NoteProperty -Name password -Value "" -ErrorAction SilentlyContinue
 
@@ -3530,7 +3534,7 @@ function Global:Get-OciLdapConfiguration {
 #>
 function Global:Update-OciLdapConfiguration {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                    Position=0,
@@ -3552,17 +3556,17 @@ function Global:Update-OciLdapConfiguration {
                    Position=15,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
-        $Uri = $Server.BaseUri + "/rest/v1/admin/ldap"           
- 
+        $Uri = $Server.BaseUri + "/rest/v1/admin/ldap"
+
         try {
             $Input = @{"isEnabled"=$isEnabled;
                         "directoryLookup"=$DirectoryLookup;
@@ -3573,14 +3577,14 @@ function Global:Update-OciLdapConfiguration {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PUT -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "PUT to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-           
+
         Write-Output $Result
     }
 }
@@ -3593,7 +3597,7 @@ function Global:Update-OciLdapConfiguration {
 #>
 function Global:Test-OciLdapConfiguration {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                    Position=0,
@@ -3611,31 +3615,31 @@ function Global:Test-OciLdapConfiguration {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
-        $Uri = $Server.BaseUri + "/rest/v1/admin/ldap/test"            
- 
+        $Uri = $Server.BaseUri + "/rest/v1/admin/ldap/test"
+
         try {
             $Body = ConvertTo-Json -InputObject @{"server"=$LdapServer;"userName"=$UserName;"password"=$Password} -Compress
             Write-Verbose "Body: $Body"
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method POST -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "POST to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-           
+
         Write-Output $Result
     }
 }
@@ -3652,37 +3656,37 @@ function Global:Test-OciLdapConfiguration {
 #>
 function Global:Get-OciLicenses {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                    Position=0,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/admin/license"
- 
+
         try {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
 
-        $LicenseStatus = ParseLicenseStatus($Result)
-           
+        $LicenseStatus = ParseLicenseStatus -LicenseStatus $Result
+
         Write-Output $LicenseStatus
     }
 }
@@ -3699,7 +3703,7 @@ function Global:Get-OciLicenses {
 #>
 function Global:Update-OciLicenses {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                    Position=0,
@@ -3708,31 +3712,31 @@ function Global:Update-OciLicenses {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
-        $Uri = $Server.BaseUri + "/rest/v1/admin/license"            
- 
+        $Uri = $Server.BaseUri + "/rest/v1/admin/license"
+
         try {
             $Body = $Licenses | ConvertTo-Json -Compress
             Write-Verbose "Body: $Body"
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PATCH -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "PATCH to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-           
+
         Write-Output $Result
     }
 }
@@ -3741,7 +3745,7 @@ function Global:Update-OciLicenses {
     .SYNOPSIS
     Replace license information
     .DESCRIPTION
-    Replace license information     
+    Replace license information
     .PARAMETER Licenses
     List of OCI Licenses
     .PARAMETER server
@@ -3749,7 +3753,7 @@ function Global:Update-OciLicenses {
 #>
 function Global:Replace-OciLicenses {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                    Position=0,
@@ -3758,31 +3762,31 @@ function Global:Replace-OciLicenses {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
-        $Uri = $Server.BaseUri + "/rest/v1/admin/license"            
- 
+        $Uri = $Server.BaseUri + "/rest/v1/admin/license"
+
         try {
             $Body = $Licenses | ConvertTo-Json -Compress
             Write-Verbose "Body: $Body"
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method POST -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "POST to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-           
+
         Write-Output $Result
     }
 }
@@ -3803,7 +3807,7 @@ function Global:Replace-OciLicenses {
 #>
 function Global:Get-OciPatches {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                     Position=0,
@@ -3815,7 +3819,7 @@ function Global:Get-OciPatches {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -3834,27 +3838,27 @@ function Global:Get-OciPatches {
             }
         }
     }
-   
+
     Process {
-        $Uri = $Server.BaseUri + "/rest/v1/admin/patches"        
- 
+        $Uri = $Server.BaseUri + "/rest/v1/admin/patches"
+
         if ($expand) {
             $Uri += "?$($Separator)expand=$expand"
         }
- 
+
         try {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-           
-        $PatchStatus = ParsePatchStatus($Result)
+
+        $PatchStatus = ParsePatchStatus -PatchStatus $Result
         Write-Output $PatchStatus
     }
 }
@@ -3869,7 +3873,7 @@ function Global:Get-OciPatches {
 #>
 function Global:Add-OciPatch {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -3881,7 +3885,7 @@ function Global:Add-OciPatch {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -3900,23 +3904,23 @@ function Global:Add-OciPatch {
             }
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/admin/patches"
- 
+
         try {
             $Result = Invoke-MultipartFormDataUpload -InFile $patchFile -Name "patchFile" -Uri $Uri -Header $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "POST to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-           
-        $PatchStatus = ParsePatchStatus($Result)
+
+        $PatchStatus = ParsePatchStatus -PatchStatus $Result
         Write-Output $PatchStatus
     }
 }
@@ -3937,7 +3941,7 @@ function Global:Add-OciPatch {
 #>
 function Global:Get-OciPatch {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -3954,7 +3958,7 @@ function Global:Get-OciPatch {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -3973,26 +3977,26 @@ function Global:Get-OciPatch {
             }
         }
     }
-   
+
     Process {
-        $Uri = $Server.BaseUri + "/rest/v1/admin/patches/$id"            
- 
+        $Uri = $Server.BaseUri + "/rest/v1/admin/patches/$id"
+
         if ($expand) {
             $Uri += "?$($Separator)expand=$expand"
         }
- 
-        try {               
+
+        try {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-          
+
         Write-Output $Result
     }
 }
@@ -4011,7 +4015,7 @@ function Global:Get-OciPatch {
 #>
 function Global:Update-OciPatch {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -4028,7 +4032,7 @@ function Global:Update-OciPatch {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -4047,10 +4051,10 @@ function Global:Update-OciPatch {
             }
         }
     }
-   
+
     Process {
-        $Uri = $Server.BaseUri + "/rest/v1/admin/patches/$id"            
- 
+        $Uri = $Server.BaseUri + "/rest/v1/admin/patches/$id"
+
         if ($fromTime -or $toTime -or $expand) {
             $Uri += '?'
             $Separator = ''
@@ -4066,20 +4070,20 @@ function Global:Update-OciPatch {
                 $Uri += "$($Separator)expand=$expand"
             }
         }
- 
+
         try {
             $Result = Invoke-MultipartFormDataUpload -InFile $patchFile -Name "patchFile" -Uri $Uri -Header $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "POST to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-           
-        $PatchStatus = ParsePatchStatus($Result)
+
+        $PatchStatus = ParsePatchStatus -PatchStatus $Result
         Write-Output $PatchStatus
     }
 }
@@ -4096,7 +4100,7 @@ function Global:Update-OciPatch {
 #>
 function Global:Approve-OciPatch {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -4107,31 +4111,31 @@ function Global:Approve-OciPatch {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
-        $Uri = $Server.BaseUri + "/rest/v1/admin/patches/$id/approve"            
- 
+        $Uri = $Server.BaseUri + "/rest/v1/admin/patches/$id/approve"
+
         try {
             $Body = ""
             Write-Verbose "Body: $Body"
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method POST -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "POST to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-           
+
         Write-Output $Result
     }
 }
@@ -4150,7 +4154,7 @@ function Global:Approve-OciPatch {
 #>
 function Global:Get-OciPatchDatasourceConclusions {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -4164,33 +4168,33 @@ function Global:Get-OciPatchDatasourceConclusions {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/admin/patches/$id/datasourceConclusions"
- 
+
         if ($expand) {
             $Uri += "?$($Separator)expand=$expand"
         }
- 
+
         try {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-           
+
         Write-Output $Result
     }
 }
@@ -4199,7 +4203,7 @@ function Global:Get-OciPatchDatasourceConclusions {
     .SYNOPSIS
     Update one patch note
     .DESCRIPTION
-    Update one patch note  
+    Update one patch note
     .PARAMETER id
     ID of patch to update
     .PARAMETER note
@@ -4209,7 +4213,7 @@ function Global:Get-OciPatchDatasourceConclusions {
 #>
 function Global:Update-OciPatchNote {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -4223,31 +4227,31 @@ function Global:Update-OciPatchNote {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
-        $Uri = $Server.BaseUri + "/rest/v1/admin/patches/$id/note"            
- 
+        $Uri = $Server.BaseUri + "/rest/v1/admin/patches/$id/note"
+
         try {
             $Body = @{value=$value} | ConvertTo-Json -Compress
             Write-Verbose "Body: $Body"
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PUT -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "PUT to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-           
+
         Write-Output $Result
     }
 }
@@ -4264,7 +4268,7 @@ function Global:Update-OciPatchNote {
 #>
 function Global:Rollback-OciPatch {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -4275,7 +4279,7 @@ function Global:Rollback-OciPatch {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -4294,12 +4298,12 @@ function Global:Rollback-OciPatch {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/admin/patches/$id/rollback"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/admin/patches/$id/rollback"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -4315,7 +4319,7 @@ function Global:Rollback-OciPatch {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 if ('POST' -match 'PUT|POST') {
                     Write-Verbose "Body: "
@@ -4326,14 +4330,14 @@ function Global:Rollback-OciPatch {
                 }
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "POST to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -4351,20 +4355,20 @@ function Global:Rollback-OciPatch {
 #>
 function Global:Get-OciUsers {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                    Position=0,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/admin/users"
 
@@ -4372,15 +4376,15 @@ function Global:Get-OciUsers {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
 
-        $Users = ParseUsers($Result)
+        $Users = ParseUsers -Users $Result
         Write-Output $Users
     }
 }
@@ -4400,19 +4404,19 @@ function Global:Get-OciUsers {
     "insightRole": "USER",
     "isActive": false
 }
-</pre>      
+</pre>
     .PARAMETER server
     OCI Server to connect to
 #>
 function Global:Add-OciUsers {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                    Position=0,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -4431,12 +4435,12 @@ function Global:Add-OciUsers {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/admin/users"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/admin/users"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -4452,7 +4456,7 @@ function Global:Add-OciUsers {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 if ('POST' -match 'PUT|POST') {
                     Write-Verbose "Body: "
@@ -4463,14 +4467,14 @@ function Global:Add-OciUsers {
                 }
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "POST to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -4486,36 +4490,36 @@ function Global:Add-OciUsers {
 #>
 function Global:Get-OciCurrentUser {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                    Position=0,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/admin/users/current"
- 
+
         try {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-        
-        $User = ParseUsers($Result)
+
+        $User = ParseUsers -Users $Result
         Write-Output $User
     }
 }
@@ -4525,7 +4529,7 @@ function Global:Get-OciCurrentUser {
     .SYNOPSIS
     Delete one user
     .DESCRIPTION
-    
+
     .PARAMETER id
     The id of user to delete
     .PARAMETER server
@@ -4533,7 +4537,7 @@ function Global:Get-OciCurrentUser {
 #>
 function Global:Remove-OciUser {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -4544,7 +4548,7 @@ function Global:Remove-OciUser {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -4563,12 +4567,12 @@ function Global:Remove-OciUser {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/admin/users/$id"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/admin/users/$id"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -4584,7 +4588,7 @@ function Global:Remove-OciUser {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 if ('DELETE' -match 'PUT|POST') {
                     Write-Verbose "Body: "
@@ -4595,14 +4599,14 @@ function Global:Remove-OciUser {
                 }
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -4620,7 +4624,7 @@ function Global:Remove-OciUser {
 #>
 function Global:Get-OciUser {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -4631,32 +4635,32 @@ function Global:Get-OciUser {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/admin/users/$id"
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $User = ParseUsers($Result)
+            $User = ParseUsers -Users $Result
             Write-Output $User
         }
     }
@@ -4677,7 +4681,7 @@ function Global:Get-OciUser {
     "isActive": false
 }
 </pre>
-            
+
     .PARAMETER id
     The id of user to update
     .PARAMETER server
@@ -4685,7 +4689,7 @@ function Global:Get-OciUser {
 #>
 function Global:Update-OciUser {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -4696,7 +4700,7 @@ function Global:Update-OciUser {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -4715,12 +4719,12 @@ function Global:Update-OciUser {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/admin/users/$id"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/admin/users/$id"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -4736,7 +4740,7 @@ function Global:Update-OciUser {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 if ('PUT' -match 'PUT|POST') {
                     Write-Verbose "Body: "
@@ -4747,14 +4751,14 @@ function Global:Update-OciUser {
                 }
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "PUT to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -4772,35 +4776,35 @@ function Global:Update-OciUser {
 #>
 function Global:Get-OciAnnotations {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/assets/annotations"
- 
+
         try {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-           
+
         Write-Output $Result
     }
 }
@@ -4823,7 +4827,7 @@ function Global:Get-OciAnnotations {
 #>
 function Global:Add-OciAnnotation {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                    Position=1,
@@ -4841,19 +4845,19 @@ function Global:Add-OciAnnotation {
                    Position=5,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/assets/annotations"
- 
+
             if ($type -match "ENUM" -and -not $enumValues) {
                 throw "$type specified, but no enumValues provided"
             }
@@ -4864,14 +4868,14 @@ function Global:Add-OciAnnotation {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method POST -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "POST to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -4890,7 +4894,7 @@ function Global:Add-OciAnnotation {
 #>
 function Global:Remove-OciAnnotation {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -4901,32 +4905,32 @@ function Global:Remove-OciAnnotation {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/assets/annotations/$id"
- 
+
             try {
                 Write-Verbose "Body: "
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers -Body "" -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -4944,7 +4948,7 @@ function Global:Remove-OciAnnotation {
 #>
 function Global:Get-OciAnnotation {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -4955,32 +4959,32 @@ function Global:Get-OciAnnotation {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/assets/annotations/$id"
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Annotation = ParseAnnotations($Result)
+            $Annotation = ParseAnnotations -Annotations $Result
             Write-Output $Annotation
         }
     }
@@ -5013,7 +5017,7 @@ function Global:Get-OciAnnotation {
     ]
 }
 </pre>
-        
+
     .PARAMETER id
     Id or name of annotation definition to update
     .PARAMETER server
@@ -5021,7 +5025,7 @@ function Global:Get-OciAnnotation {
 #>
 function Global:Update-OciAnnotation {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -5032,19 +5036,19 @@ function Global:Update-OciAnnotation {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/assets/annotations/$id"
- 
+
             try {
                 if ('PATCH' -match 'PUT|POST') {
                     Write-Verbose "Body: "
@@ -5055,14 +5059,14 @@ function Global:Update-OciAnnotation {
                 }
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "PATCH to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -5072,7 +5076,7 @@ function Global:Update-OciAnnotation {
     .SYNOPSIS
     Remove object annotation values in bulk by annotation
     .DESCRIPTION
-    Remove object annotation values in bulk by annotation    
+    Remove object annotation values in bulk by annotation
     .PARAMETER id
     Id or name of annotation to remove values from
     .PARAMETER objectType
@@ -5084,7 +5088,7 @@ function Global:Update-OciAnnotation {
 #>
 function Global:Remove-OciAnnotationValues {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -5101,14 +5105,14 @@ function Global:Remove-OciAnnotationValues {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
@@ -5125,7 +5129,7 @@ function Global:Remove-OciAnnotationValues {
             try {
                 foreach ($item in $items) {
                     $objectType = $item.objectType
-                    $targets = $item.values.targets | % { $_ -split '/' | select -last 1 }
+                    $targets = $item.values.targets | ForEach-Object { $_ -split '/' | Select-Object -last 1 }
                     if ($targets) {
                         $Body = ConvertTo-Json @(@{objectType=$objectType;targets=$targets}) -Compress -Depth 4
                         Write-Verbose "Body: $Body"
@@ -5134,14 +5138,14 @@ function Global:Remove-OciAnnotationValues {
                 }
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -5159,7 +5163,7 @@ function Global:Remove-OciAnnotationValues {
 #>
 function Global:Get-OciAnnotationValues {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -5170,31 +5174,31 @@ function Global:Get-OciAnnotationValues {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/assets/annotations/$id/values"
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -5204,7 +5208,7 @@ function Global:Get-OciAnnotationValues {
     .SYNOPSIS
     Update object annotations in bulk by annotation
     .DESCRIPTION
-    Update object annotations in bulk by annotation     
+    Update object annotations in bulk by annotation
     .PARAMETER id
     Id or name of annotation definition to update
     .PARAMETER objectType
@@ -5218,7 +5222,7 @@ function Global:Get-OciAnnotationValues {
 #>
 function Global:Update-OciAnnotationValues {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -5238,14 +5242,14 @@ function Global:Update-OciAnnotationValues {
                    Position=4,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
@@ -5257,14 +5261,14 @@ function Global:Update-OciAnnotationValues {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PUT -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "PUT to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -5284,7 +5288,7 @@ function Global:Update-OciAnnotationValues {
 #>
 function Global:Get-OciAnnotationValuesByObjectType {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -5298,31 +5302,31 @@ function Global:Get-OciAnnotationValuesByObjectType {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/assets/annotations/$id/values/$objectType"
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -5345,7 +5349,7 @@ function Global:Get-OciAnnotationValuesByObjectType {
 #>
 function Global:Update-OciAnnotationValuesByObjectTypeAndValue {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -5362,7 +5366,7 @@ function Global:Update-OciAnnotationValuesByObjectTypeAndValue {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -5381,12 +5385,12 @@ function Global:Update-OciAnnotationValuesByObjectTypeAndValue {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/annotations/$id/values/{objectType}/{value}"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/annotations/$id/values/{objectType}/{value}"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -5402,7 +5406,7 @@ function Global:Update-OciAnnotationValuesByObjectTypeAndValue {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 if ('GET' -match 'PUT|POST') {
                     Write-Verbose "Body: "
@@ -5413,14 +5417,14 @@ function Global:Update-OciAnnotationValuesByObjectTypeAndValue {
                 }
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-       
+
             Write-Output $Result
         }
     }
@@ -5448,7 +5452,7 @@ function Global:Update-OciAnnotationValuesByObjectTypeAndValue {
 #>
 function Global:Get-OciApplications {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                     Position=0,
@@ -5469,7 +5473,7 @@ function Global:Get-OciApplications {
                    Position=5,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -5488,11 +5492,11 @@ function Global:Get-OciApplications {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/applications"            
+            $Uri = $Server.BaseUri + "/rest/v1/assets/applications"
 
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
@@ -5509,20 +5513,20 @@ function Global:Get-OciApplications {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
-            $Applications = ParseApplications($Result)
+
+            $Applications = ParseApplications -Applications $Result
             Write-Output $Applications
         }
     }
@@ -5548,7 +5552,7 @@ function Global:Get-OciApplications {
 #>
 function Global:Add-OciApplication {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -5572,7 +5576,7 @@ function Global:Add-OciApplication {
                    Position=6,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -5594,7 +5598,7 @@ function Global:Add-OciApplication {
 
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/assets/applications"
- 
+
         if ($fromTime -or $toTime -or $expand) {
             $Uri += '?'
             $Separator = ''
@@ -5610,7 +5614,7 @@ function Global:Add-OciApplication {
                 $Uri += "$($Separator)expand=$expand"
             }
         }
- 
+
         try {
             if ($businessEntity) {
                 $Body = ConvertTo-Json @{name=$name;priority=$priority;businessEntity=@{id=$businessEntity};ignoreShareViolations=$($ignoreShareViolations.IsPresent)} -Compress
@@ -5622,15 +5626,15 @@ function Global:Add-OciApplication {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method POST -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "POST to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-           
-        $Application = ParseApplications($Result)
+
+        $Application = ParseApplications -Applications $Result
         Write-Output $Application
     }
 }
@@ -5675,7 +5679,7 @@ function Global:Add-OciApplication {
     }
 ]
 </pre>
-            
+
     .PARAMETER computeResources
     Return list of related Compute resources
     .PARAMETER storageResources
@@ -5685,7 +5689,7 @@ function Global:Add-OciApplication {
 #>
 function Global:Remove-OciApplicationsFromAssets {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                     Position=0,
@@ -5697,7 +5701,7 @@ function Global:Remove-OciApplicationsFromAssets {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -5716,12 +5720,12 @@ function Global:Remove-OciApplicationsFromAssets {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/applications/assets"           
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/applications/assets"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -5737,7 +5741,7 @@ function Global:Remove-OciApplicationsFromAssets {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 if ('DELETE' -match 'PUT|POST') {
                     Write-Verbose "Body: "
@@ -5748,14 +5752,14 @@ function Global:Remove-OciApplicationsFromAssets {
                 }
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -5800,7 +5804,7 @@ function Global:Remove-OciApplicationsFromAssets {
         ]
     }
 ]
-</pre>     
+</pre>
     .PARAMETER computeResources
     Return list of related Compute resources
     .PARAMETER storageResources
@@ -5810,7 +5814,7 @@ function Global:Remove-OciApplicationsFromAssets {
 #>
 function Global:Add-OciApplicationsToAssets {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                     Position=0,
@@ -5822,7 +5826,7 @@ function Global:Add-OciApplicationsToAssets {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -5841,12 +5845,12 @@ function Global:Add-OciApplicationsToAssets {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/applications/assets"           
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/applications/assets"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -5862,7 +5866,7 @@ function Global:Add-OciApplicationsToAssets {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 if ('PATCH' -match 'PUT|POST') {
                     Write-Verbose "Body: "
@@ -5873,14 +5877,14 @@ function Global:Add-OciApplicationsToAssets {
                 }
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "PATCH to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -5902,7 +5906,7 @@ function Global:Add-OciApplicationsToAssets {
 #>
 function Global:Remove-OciApplication {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -5919,7 +5923,7 @@ function Global:Remove-OciApplication {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -5938,12 +5942,12 @@ function Global:Remove-OciApplication {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/assets/applications/$id"
- 
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -5959,20 +5963,20 @@ function Global:Remove-OciApplication {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
-            $Application = ParseApplications($Result)
+
+            $Application = ParseApplications -Applications $Result
             Write-Output $Application
         }
     }
@@ -6000,7 +6004,7 @@ function Global:Remove-OciApplication {
 #>
 function Global:Get-OciApplication {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -6026,7 +6030,7 @@ function Global:Get-OciApplication {
                    Position=6,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -6045,12 +6049,12 @@ function Global:Get-OciApplication {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/assets/applications/$id"
-                      
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -6066,20 +6070,20 @@ function Global:Get-OciApplication {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-            
-            $Application = ParseApplications($Result)
+
+            $Application = ParseApplications -Applications $Result
             Write-Output $Application
         }
     }
@@ -6089,9 +6093,9 @@ function Global:Get-OciApplication {
     .SYNOPSIS
     Update an application
     .DESCRIPTION
-    Update an application  
+    Update an application
     .PARAMETER id
-    Id of application to update 
+    Id of application to update
     .PARAMETER priority
     Application priority (Critical, High, Medium or Low). Default is Medium.
     .PARAMETER businessEntity
@@ -6105,7 +6109,7 @@ function Global:Get-OciApplication {
 #>
 function Global:Update-OciApplication {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -6131,7 +6135,7 @@ function Global:Update-OciApplication {
                    Position=6,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -6150,12 +6154,12 @@ function Global:Update-OciApplication {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/applications/$id"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/applications/$id"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -6171,7 +6175,7 @@ function Global:Update-OciApplication {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 if ($businessEntity) {
                     $Body = ConvertTo-Json @{name=$name;priority=$priority;businessEntity=@{id=$businessEntity};ignoreShareViolations=$($ignoreShareViolations.IsPresent)} -Compress
@@ -6183,15 +6187,15 @@ function Global:Update-OciApplication {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PUT -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "PUT to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
-            $Application = ParseApplications($Result)
+
+            $Application = ParseApplications -Applications $Result
             Write-Output $Application
         }
     }
@@ -6222,7 +6226,7 @@ function Global:Update-OciApplication {
     }
 ]
 </pre>
-            
+
     .PARAMETER id
     Id of application to un-assign from assets
     .PARAMETER server
@@ -6230,7 +6234,7 @@ function Global:Update-OciApplication {
 #>
 function Global:Bulk-OciUnAssignApplicationFromAssets {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -6241,7 +6245,7 @@ function Global:Bulk-OciUnAssignApplicationFromAssets {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -6260,12 +6264,12 @@ function Global:Bulk-OciUnAssignApplicationFromAssets {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/applications/$id/assets"           
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/applications/$id/assets"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -6281,7 +6285,7 @@ function Global:Bulk-OciUnAssignApplicationFromAssets {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 if ('DELETE' -match 'PUT|POST') {
                     Write-Verbose "Body: "
@@ -6292,14 +6296,14 @@ function Global:Bulk-OciUnAssignApplicationFromAssets {
                 }
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -6321,7 +6325,7 @@ function Global:Bulk-OciUnAssignApplicationFromAssets {
 #>
 function Global:Get-OciAssetsByApplication {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -6338,19 +6342,19 @@ function Global:Get-OciAssetsByApplication {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/assets/applications/$id/assets"
- 
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -6366,19 +6370,19 @@ function Global:Get-OciAssetsByApplication {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -6409,7 +6413,7 @@ function Global:Get-OciAssetsByApplication {
     }
 ]
 </pre>
-            
+
     .PARAMETER id
     Id of application to assign to assets
     .PARAMETER server
@@ -6417,7 +6421,7 @@ function Global:Get-OciAssetsByApplication {
 #>
 function Global:Bulk-OciAssignApplicationToAssets {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -6425,7 +6429,7 @@ function Global:Bulk-OciAssignApplicationToAssets {
                     ValueFromPipeline=$True,
                     ValueFromPipelineByPropertyName=$True)][Long[]]$id
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -6444,12 +6448,12 @@ function Global:Bulk-OciAssignApplicationToAssets {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/assets/applications/$id/assets"
- 
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -6465,7 +6469,7 @@ function Global:Bulk-OciAssignApplicationToAssets {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 if ('PATCH' -match 'PUT|POST') {
                     Write-Verbose "Body: "
@@ -6476,14 +6480,14 @@ function Global:Bulk-OciAssignApplicationToAssets {
                 }
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "PATCH to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -6517,7 +6521,7 @@ function Global:Bulk-OciAssignApplicationToAssets {
 #>
 function Global:Get-OciComputeResourcesByApplication {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -6552,7 +6556,7 @@ function Global:Get-OciComputeResourcesByApplication {
                    Position=9,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -6571,7 +6575,7 @@ function Global:Get-OciComputeResourcesByApplication {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
@@ -6592,20 +6596,20 @@ function Global:Get-OciComputeResourcesByApplication {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-            
-            $ComputeResources = ParseComputeResources($Result)
+
+            $ComputeResources = ParseComputeResources -ComputeResources $Result
             Write-Output $ComputeResources
         }
     }
@@ -6643,7 +6647,7 @@ function Global:Get-OciComputeResourcesByApplication {
 #>
 function Global:Get-OciStorageResourcesByApplication {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -6684,7 +6688,7 @@ function Global:Get-OciStorageResourcesByApplication {
                    Position=11,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -6703,7 +6707,7 @@ function Global:Get-OciStorageResourcesByApplication {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
@@ -6724,20 +6728,20 @@ function Global:Get-OciStorageResourcesByApplication {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-            
-            $StorageResources = ParseStorageResources($Result)
+
+            $StorageResources = ParseStorageResources -StorageResources $Result
             Write-Output $StorageResources
         }
     }
@@ -6755,35 +6759,35 @@ function Global:Get-OciStorageResourcesByApplication {
 #>
 function Global:Get-OciBusinessEntities {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                    Position=0,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/assets/businessEntities"
- 
+
         try {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-           
+
         Write-Output $Result
     }
 }
@@ -6798,7 +6802,7 @@ function Global:Get-OciBusinessEntities {
 #>
 function Global:Add-OciBusinessEntity {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                    Position=0,
@@ -6816,31 +6820,31 @@ function Global:Add-OciBusinessEntity {
                    Position=4,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/assets/businessEntities"
- 
+
         try {
             $Body = @{tenant=$Tenant;lob=$LineOfBusiness;businessUnit=$BusinessUnit;project=$project} | ConvertTo-Json -Compress
             Write-Verbose "Body: $Body"
-            $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method POST -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'            
+            $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method POST -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "POST to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-           
+
         Write-Output $Result
     }
 }
@@ -6857,7 +6861,7 @@ function Global:Add-OciBusinessEntity {
 #>
 function Global:Remove-OciBusinessEntity {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -6868,29 +6872,29 @@ function Global:Remove-OciBusinessEntity {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/assets/businessEntities/$id"
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -6910,7 +6914,7 @@ function Global:Remove-OciBusinessEntity {
 #>
 function Global:Get-OciBusinessEntity {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -6921,31 +6925,31 @@ function Global:Get-OciBusinessEntity {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/assets/businessEntities/$id"
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -6989,7 +6993,7 @@ function Global:Get-OciBusinessEntity {
 #>
 function Global:Get-OciDatastores {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                     Position=0,
@@ -7010,14 +7014,14 @@ function Global:Get-OciDatastores {
                    Position=5,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
@@ -7028,7 +7032,7 @@ function Global:Get-OciDatastores {
             }
 
             $Uri = $($Server.BaseUri) + "/rest/v1/assets/dataStores"
-            
+
             $Uri += '?'
             $Separator = ''
             if ($limit) {
@@ -7042,26 +7046,26 @@ function Global:Get-OciDatastores {
             if ($expand) {
                 $Uri += "$($Separator)expand=$expand"
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-            
-            $Datastores = ParseDatastores $Result $Timezone
-                  
+
+            $Datastores = ParseDatastores -Datastores $Result -Timezone $Timezone
+
             if ($Datastores) { Write-Output $Datastores }
 
             if ($FetchAll -and @($Datastores).Count -eq $Limit) {
                 $Offset += $Limit
-                Get-OciDatastores -fromTime $fromTime -toTime $toTime -performance:$performance -sort $sort -limit $limit -offset $offset -hosts:$hosts -vmdks:$vmdks -datasources:$datasources -storageResources:$storageResources -annotations:$annotations -Server $Server
+                Get-OciDatastores -fromTime $fromTime -toTime $toTime -limit $limit -offset $offset -Server $Server
             }
         }
     }
@@ -7077,35 +7081,35 @@ function Global:Get-OciDatastores {
 #>
 function Global:Get-OciDatastoreCount {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                    Position=0,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/assets/dataStores/count"
-      
+
         try {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-           
+
         Write-Output $Result.value
     }
 }
@@ -7142,7 +7146,7 @@ function Global:Get-OciDatastoreCount {
 #>
 function Global:Get-OciDatastore {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -7183,7 +7187,7 @@ function Global:Get-OciDatastore {
                    Position=11,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -7201,12 +7205,12 @@ function Global:Get-OciDatastore {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/assets/dataStores/$id"
- 
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -7222,20 +7226,20 @@ function Global:Get-OciDatastore {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
-            $Datastore = ParseDatastores $Result $Timezone
+
+            $Datastore = ParseDatastores -Datastores $Result -Timezone $Timezone
             Write-Output $Datastore
         }
     }
@@ -7245,7 +7249,7 @@ function Global:Get-OciDatastore {
     .SYNOPSIS
     Delete annotations from object
     .DESCRIPTION
-    Delete annotations from object   
+    Delete annotations from object
     .PARAMETER id
     Id of datastore where annotation should be deleted
     .PARAMATER annotationId
@@ -7257,7 +7261,7 @@ function Global:Get-OciDatastore {
 #>
 function Global:Remove-OciAnnotationsByDatastore {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -7274,14 +7278,14 @@ function Global:Remove-OciAnnotationsByDatastore {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $CurrentOciServer.BaseUri + "/rest/v1/assets/dataStores/$id/annotations"
 
@@ -7291,23 +7295,23 @@ function Global:Remove-OciAnnotationsByDatastore {
 
         if (!$Annotations) {
             $Annotations = Get-OciAnnotationsByDatastore -id $id -definition -Server $Server
-        }      
- 
+        }
+
         try {
             $Body = ConvertTo-Json @($Annotations | ConvertTo-AnnotationValues) -Compress
             Write-Verbose "Body: $Body"
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-       
-        $AnnotationValues = ParseAnnotationValues($Result)
+
+        $AnnotationValues = ParseAnnotationValues -AnnotationValues $Result
         Write-Output $AnnotationValues
     }
 }
@@ -7328,7 +7332,7 @@ function Global:Remove-OciAnnotationsByDatastore {
 #>
 function Global:Get-OciAnnotationsByDatastore {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -7345,35 +7349,35 @@ function Global:Get-OciAnnotationsByDatastore {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
-        $Uri = $Server.BaseUri + "/rest/v1/assets/dataStores/$id/annotations"            
- 
+        $Uri = $Server.BaseUri + "/rest/v1/assets/dataStores/$id/annotations"
+
         if ($definition) {
             $Uri += "?expand=definition"
         }
- 
+
         try {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-            
-        $Annotations = ParseAnnotations($Result)
-            
+
+        $Annotations = ParseAnnotations -Annotations $Result
+
         Write-Output $Annotations
     }
 }
@@ -7382,7 +7386,7 @@ function Global:Get-OciAnnotationsByDatastore {
     .SYNOPSIS
     Update annotations for datastore
     .DESCRIPTION
-    Update annotations for datastore      
+    Update annotations for datastore
     .PARAMETER id
     Id of datastore to update
     .PARAMETER Annotations
@@ -7394,7 +7398,7 @@ function Global:Get-OciAnnotationsByDatastore {
 #>
 function Global:Update-OciAnnotationsByDatastore {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -7411,36 +7415,36 @@ function Global:Update-OciAnnotationsByDatastore {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
-        $Uri = $Server.BaseUri + "/rest/v1/assets/dataStores/$id/annotations"            
- 
+        $Uri = $Server.BaseUri + "/rest/v1/assets/dataStores/$id/annotations"
+
         if ($definition) {
             $Uri += "?expand=definition"
         }
- 
+
         try {
             $Body = ConvertTo-Json @($Annotations | ConvertTo-AnnotationValues) -Compress
             Write-Verbose "Body: $Body"
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PUT -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "PUT to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
 
-        $AnnotationValues = ParseAnnotationValues($Result)
+        $AnnotationValues = ParseAnnotationValues -AnnotationValues $Result
         Write-Output $AnnotationValues
     }
 }
@@ -7479,7 +7483,7 @@ function Global:Update-OciAnnotationsByDatastore {
 #>
 function Global:Get-OciDatasourcesByDataStore {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -7523,7 +7527,7 @@ function Global:Get-OciDatasourcesByDataStore {
                    Position=12,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -7542,12 +7546,12 @@ function Global:Get-OciDatasourcesByDataStore {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/dataStores/$id/datasources"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/dataStores/$id/datasources"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -7563,21 +7567,21 @@ function Global:Get-OciDatasourcesByDataStore {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-            
-            $Datasources = ParseDatasources($Result)
-            
+
+            $Datasources = ParseDatasources -Datasources $Result
+
             Write-Output $Datasources
         }
     }
@@ -7623,7 +7627,7 @@ function Global:Get-OciDatasourcesByDataStore {
 #>
 function Global:Get-OciHostsByDatastore {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -7673,7 +7677,7 @@ function Global:Get-OciHostsByDatastore {
                    Position=14,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -7692,12 +7696,12 @@ function Global:Get-OciHostsByDatastore {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/dataStores/$id/hosts"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/dataStores/$id/hosts"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -7713,21 +7717,21 @@ function Global:Get-OciHostsByDatastore {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Hosts = ParseHosts($Result,$Server.Timezone)
-            
+            $Hosts = ParseHosts -Hosts $Result -Timezone $Server.Timezone
+
             if ($Hosts) {
                 Write-Output $Hosts
             }
@@ -7755,7 +7759,7 @@ function Global:Get-OciHostsByDatastore {
 #>
 function Global:Get-OciDatastorePerformance {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -7775,19 +7779,19 @@ function Global:Get-OciDatastorePerformance {
                    Position=5,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/dataStores/$id/performance"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/dataStores/$id/performance"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -7803,20 +7807,20 @@ function Global:Get-OciDatastorePerformance {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Performance = ParsePerformance($Result,$Server.Timezone)
+            $Performance = ParsePerformance -Performance $Result -Timezone $Server.Timezone
             Write-Output $Performance
         }
     }
@@ -7854,7 +7858,7 @@ function Global:Get-OciDatastorePerformance {
 #>
 function Global:Get-OciStorageResourcesByDatastore {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -7895,7 +7899,7 @@ function Global:Get-OciStorageResourcesByDatastore {
                    Position=11,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -7914,12 +7918,12 @@ function Global:Get-OciStorageResourcesByDatastore {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/dataStores/$id/storageResources"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/dataStores/$id/storageResources"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -7935,20 +7939,20 @@ function Global:Get-OciStorageResourcesByDatastore {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-       
-            $StorageResources = ParseStorageResources($Result)
+
+            $StorageResources = ParseStorageResources -StorageResources $Result
             Write-Output $StorageResources
         }
     }
@@ -7986,7 +7990,7 @@ function Global:Get-OciStorageResourcesByDatastore {
 #>
 function Global:Get-OciVmdksByDatastore {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -8027,7 +8031,7 @@ function Global:Get-OciVmdksByDatastore {
                    Position=11,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -8046,12 +8050,12 @@ function Global:Get-OciVmdksByDatastore {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/dataStores/$id/vmdks"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/dataStores/$id/vmdks"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -8067,21 +8071,21 @@ function Global:Get-OciVmdksByDatastore {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Vmdks = ParseVmdks($Result,$Server.Timezone)
-           
+            $Vmdks = ParseVmdks -Vmdks $Result -Timezone $Server.Timezone
+
             Write-Output $Vmdks
         }
     }
@@ -8123,7 +8127,7 @@ function Global:Get-OciVmdksByDatastore {
 #>
 function Global:Get-OciDisk {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -8167,7 +8171,7 @@ function Global:Get-OciDisk {
                    Position=12,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -8186,12 +8190,12 @@ function Global:Get-OciDisk {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/disks/$id"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/disks/$id"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -8207,20 +8211,20 @@ function Global:Get-OciDisk {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
-            $Disks = ParseDisks($Result)
+
+            $Disks = ParseDisks -Disks $Result
             Write-Output $Disks
         }
     }
@@ -8230,7 +8234,7 @@ function Global:Get-OciDisk {
     .SYNOPSIS
     Remove annotations from disk
     .DESCRIPTION
-    Remove annotations from disk 
+    Remove annotations from disk
     .PARAMETER id
     Id of disk where annotations should be removed from
     .PARAMETER Annotations
@@ -8242,7 +8246,7 @@ function Global:Get-OciDisk {
 #>
 function Global:Remove-OciAnnotationsByDisk {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -8259,14 +8263,14 @@ function Global:Remove-OciAnnotationsByDisk {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/assets/disks/$id/annotations"
 
@@ -8277,22 +8281,22 @@ function Global:Remove-OciAnnotationsByDisk {
         if (!$Annotations) {
             $Annotations = Get-OciAnnotationsByDisk -id $id -definition -Server $Server
         }
- 
+
         try {
             $Body = ConvertTo-Json @($Annotations | ConvertTo-AnnotationValues) -Compress
             Write-Verbose "Body: $Body"
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Body $Body -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
 
-        $AnnotationValues = ParseAnnotationValues($Result)
+        $AnnotationValues = ParseAnnotationValues -AnnotationValues $Result
         Write-Output $AnnotationValues
     }
 }
@@ -8311,7 +8315,7 @@ function Global:Remove-OciAnnotationsByDisk {
 #>
 function Global:Get-OciAnnotationsByDisk {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -8325,34 +8329,34 @@ function Global:Get-OciAnnotationsByDisk {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
-        $Uri = $Server.BaseUri + "/rest/v1/assets/disks/$id/annotations"     
-        
+        $Uri = $Server.BaseUri + "/rest/v1/assets/disks/$id/annotations"
+
         if ($definition) {
             $Uri += "?expand=definition"
-        }       
- 
+        }
+
         try {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
 
-        $Annotations = ParseAnnotations($Result)
+        $Annotations = ParseAnnotations -Annotations $Result
         Write-Output $Annotations
     }
 }
@@ -8361,7 +8365,7 @@ function Global:Get-OciAnnotationsByDisk {
     .SYNOPSIS
     Update annotations of disk
     .DESCRIPTION
-    Update annotations of disk      
+    Update annotations of disk
     .PARAMETER id
     Id of disk to update
     .PARAMETER Annotations
@@ -8373,7 +8377,7 @@ function Global:Get-OciAnnotationsByDisk {
 #>
 function Global:Update-OciAnnotationsByDisk {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -8390,32 +8394,32 @@ function Global:Update-OciAnnotationsByDisk {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
-        $Uri = $Server.BaseUri + "/rest/v1/assets/disks/$id/annotations"    
-        
+        $Uri = $Server.BaseUri + "/rest/v1/assets/disks/$id/annotations"
+
         if ($definition) {
             $Uri += "?expand=definition"
-        }        
- 
+        }
+
         try {
             $Body = ConvertTo-Json @($Annotations | ConvertTo-AnnotationValues) -Compress
             Write-Verbose "Body: $Body"
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PUT -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "PUT to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
-        $Annotations = ParseAnnotations($Result)
+
+        $Annotations = ParseAnnotations -Annotations $Result
         Write-Output $Annotations
     }
 }
@@ -8472,7 +8476,7 @@ function Global:Update-OciAnnotationsByDisk {
 #>
 function Global:Get-OciBackendVolumesByDisk {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -8543,7 +8547,7 @@ function Global:Get-OciBackendVolumesByDisk {
                    Position=21,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -8562,12 +8566,12 @@ function Global:Get-OciBackendVolumesByDisk {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/disks/$id/backendVolumes"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/disks/$id/backendVolumes"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -8583,20 +8587,20 @@ function Global:Get-OciBackendVolumesByDisk {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Volumes = ParseVolumes($Result)
+            $Volumes = ParseVolumes -Volumes $Result
             Write-Output $Volumes
         }
     }
@@ -8636,7 +8640,7 @@ function Global:Get-OciBackendVolumesByDisk {
 #>
 function Global:Get-OciDatasourcesByDisk {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -8680,7 +8684,7 @@ function Global:Get-OciDatasourcesByDisk {
                    Position=12,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -8699,12 +8703,12 @@ function Global:Get-OciDatasourcesByDisk {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/disks/$id/datasources"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/disks/$id/datasources"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -8720,20 +8724,20 @@ function Global:Get-OciDatasourcesByDisk {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Datasources = ParseDatasources($Result)
+            $Datasources = ParseDatasources -Datasources $Result
 
             Write-Output $Datasources
         }
@@ -8760,7 +8764,7 @@ function Global:Get-OciDatasourcesByDisk {
 #>
 function Global:Get-OciDiskPerformance {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -8783,7 +8787,7 @@ function Global:Get-OciDiskPerformance {
                    Position=5,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -8802,12 +8806,12 @@ function Global:Get-OciDiskPerformance {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/disks/$id/performance"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/disks/$id/performance"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -8823,20 +8827,20 @@ function Global:Get-OciDiskPerformance {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Performance = ParsePerformance($Result,$Server.Timezone)
+            $Performance = ParsePerformance -Performance $Result -Timezone $Server.Timezone
             Write-Output $Performance
         }
     }
@@ -8880,7 +8884,7 @@ function Global:Get-OciDiskPerformance {
 #>
 function Global:Get-OciStoragePoolsByDisk {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -8930,7 +8934,7 @@ function Global:Get-OciStoragePoolsByDisk {
                    Position=14,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -8949,12 +8953,12 @@ function Global:Get-OciStoragePoolsByDisk {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/disks/$id/storagePools"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/disks/$id/storagePools"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -8970,20 +8974,20 @@ function Global:Get-OciStoragePoolsByDisk {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $StoragePools = ParseStoragePools($Result)
+            $StoragePools = ParseStoragePools -StoragePools $Result
             Write-Output $StoragePools
         }
     }
@@ -9021,7 +9025,7 @@ function Global:Get-OciStoragePoolsByDisk {
 #>
 function Global:Get-OciStorageResourcesByDisk {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -9062,7 +9066,7 @@ function Global:Get-OciStorageResourcesByDisk {
                    Position=11,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -9081,12 +9085,12 @@ function Global:Get-OciStorageResourcesByDisk {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/assets/disks/$id/storageResources"
- 
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -9102,20 +9106,20 @@ function Global:Get-OciStorageResourcesByDisk {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-       
-            $StorageResources = ParseStorageResources($Result)
+
+            $StorageResources = ParseStorageResources -StorageResources $Result
             Write-Output $StorageResources
         }
     }
@@ -9147,7 +9151,7 @@ function Global:Get-OciStorageResourcesByDisk {
 #>
 function Global:Get-OciFabrics {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                     Position=0,
@@ -9174,7 +9178,7 @@ function Global:Get-OciFabrics {
                    Position=5,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -9193,7 +9197,7 @@ function Global:Get-OciFabrics {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
@@ -9203,8 +9207,8 @@ function Global:Get-OciFabrics {
                 $Limit = 50
             }
 
-            $Uri = $Server.BaseUri + "/rest/v1/assets/fabrics"                      
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/fabrics"
+
             $Uri += '?'
             $Separator = ''
             if ($fromTime) {
@@ -9226,20 +9230,20 @@ function Global:Get-OciFabrics {
             if ($expand) {
                 $Uri += "$($Separator)expand=$expand"
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Fabrics = ParseFabrics($Result)
+            $Fabrics = ParseFabrics -Fabrics $Result
             if ($Fabrics)  { Write-Output $Fabrics }
 
             if ($FetchAll -and @($Fabrics).Count -eq $Limit) {
@@ -9260,35 +9264,35 @@ function Global:Get-OciFabrics {
 #>
 function Global:Get-OciFabricCount {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                    Position=0,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/assets/fabrics/count"
- 
+
         try {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-       
+
         Write-Output $Result
     }
 }
@@ -9315,7 +9319,7 @@ function Global:Get-OciFabricCount {
 #>
 function Global:Get-OciFabric {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -9341,7 +9345,7 @@ function Global:Get-OciFabric {
                    Position=6,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -9360,12 +9364,12 @@ function Global:Get-OciFabric {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/fabrics/$id"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/fabrics/$id"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -9381,20 +9385,20 @@ function Global:Get-OciFabric {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Fabric = ParseFabrics($Result)
+            $Fabric = ParseFabrics -Fabrics $Result
             Write-Output $Fabric
         }
     }
@@ -9434,7 +9438,7 @@ function Global:Get-OciFabric {
 #>
 function Global:Get-OciDatasourcesByFabric {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -9478,7 +9482,7 @@ function Global:Get-OciDatasourcesByFabric {
                    Position=12,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -9497,12 +9501,12 @@ function Global:Get-OciDatasourcesByFabric {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/fabrics/$id/datasources"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/fabrics/$id/datasources"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -9518,20 +9522,20 @@ function Global:Get-OciDatasourcesByFabric {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
-            $Datasources = ParseDatasources($Result)
+
+            $Datasources = ParseDatasources -Datasources $Result
             Write-Output $Datasources
         }
     }
@@ -9577,7 +9581,7 @@ function Global:Get-OciDatasourcesByFabric {
 #>
 function Global:Get-OciPortsByFabric {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -9630,7 +9634,7 @@ function Global:Get-OciPortsByFabric {
                    Position=15,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -9649,7 +9653,7 @@ function Global:Get-OciPortsByFabric {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
@@ -9659,7 +9663,7 @@ function Global:Get-OciPortsByFabric {
                 $Limit = 50
             }
 
-            $Uri = $Server.BaseUri + "/rest/v1/assets/fabrics/$id/ports"                      
+            $Uri = $Server.BaseUri + "/rest/v1/assets/fabrics/$id/ports"
 
             $Uri += '?'
             $Separator = ''
@@ -9686,20 +9690,20 @@ function Global:Get-OciPortsByFabric {
             if ($expand) {
                 $Uri += "$($Separator)expand=$expand"
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Ports = ParsePorts($Result,$Server.Timezone)
+            $Ports = ParsePorts -Ports $Result -Timezone $Server.Timezone
             if ($Ports) { Write-Output $Ports }
 
             if ($FetchAll -and @($Ports).Count -eq $Limit) {
@@ -9726,7 +9730,7 @@ function Global:Get-OciPortsByFabric {
 #>
 function Global:Get-OciPortsByFabricCount {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -9743,7 +9747,7 @@ function Global:Get-OciPortsByFabricCount {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -9762,12 +9766,12 @@ function Global:Get-OciPortsByFabricCount {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/fabrics/$id/ports/count"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/fabrics/$id/ports/count"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -9783,17 +9787,17 @@ function Global:Get-OciPortsByFabricCount {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result.Value
@@ -9833,7 +9837,7 @@ function Global:Get-OciPortsByFabricCount {
 #>
 function Global:Get-OciSwitchesByFabric {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -9874,7 +9878,7 @@ function Global:Get-OciSwitchesByFabric {
                    Position=11,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -9893,12 +9897,12 @@ function Global:Get-OciSwitchesByFabric {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/fabrics/$id/switches"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/fabrics/$id/switches"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -9914,20 +9918,20 @@ function Global:Get-OciSwitchesByFabric {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Switches = ParseSwitches($Result,$Server.Timezone)
+            $Switches = ParseSwitches -Switches $Result -Timezone $Server.Timezone
             Write-Output $Switches
         }
     }
@@ -9939,7 +9943,7 @@ function Global:Get-OciSwitchesByFabric {
     .SYNOPSIS
     Retrieve one file system
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of file system to retrieve
     .PARAMETER fromTime
@@ -9959,7 +9963,7 @@ function Global:Get-OciSwitchesByFabric {
 #>
 function Global:Get-OciFilesystem {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -9988,7 +9992,7 @@ function Global:Get-OciFilesystem {
                    Position=7,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -10007,12 +10011,12 @@ function Global:Get-OciFilesystem {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/fileSystems/$id"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/fileSystems/$id"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -10028,19 +10032,19 @@ function Global:Get-OciFilesystem {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-       
+
             Write-Output $Result
         }
     }
@@ -10050,7 +10054,7 @@ function Global:Get-OciFilesystem {
     .SYNOPSIS
     Retrieve compute resource for a file system
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of file system to retrieve the compute resource for
     .PARAMETER fromTime
@@ -10074,7 +10078,7 @@ function Global:Get-OciFilesystem {
 #>
 function Global:Get-OciComputeResourceByFileSystem {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -10109,7 +10113,7 @@ function Global:Get-OciComputeResourceByFileSystem {
                    Position=9,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -10128,12 +10132,12 @@ function Global:Get-OciComputeResourceByFileSystem {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/fileSystems/$id/computeResource"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/fileSystems/$id/computeResource"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -10149,17 +10153,17 @@ function Global:Get-OciComputeResourceByFileSystem {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -10171,7 +10175,7 @@ function Global:Get-OciComputeResourceByFileSystem {
     .SYNOPSIS
     Retrieve storage resources for a file system
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of file system to retrieve the storage resources for
     .PARAMETER fromTime
@@ -10199,7 +10203,7 @@ function Global:Get-OciComputeResourceByFileSystem {
 #>
 function Global:Get-OciStorageResorcesByFileSystem {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -10240,7 +10244,7 @@ function Global:Get-OciStorageResorcesByFileSystem {
                    Position=11,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -10259,12 +10263,12 @@ function Global:Get-OciStorageResorcesByFileSystem {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/fileSystems/$id/storageResources"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/fileSystems/$id/storageResources"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -10280,19 +10284,19 @@ function Global:Get-OciStorageResorcesByFileSystem {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -10302,7 +10306,7 @@ function Global:Get-OciStorageResorcesByFileSystem {
     .SYNOPSIS
     Retrieve VMDKs for a file system
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of file system to retrieve the VMDKs for
     .PARAMETER fromTime
@@ -10330,7 +10334,7 @@ function Global:Get-OciStorageResorcesByFileSystem {
 #>
 function Global:Get-OciVmdksByFileSystem {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -10371,7 +10375,7 @@ function Global:Get-OciVmdksByFileSystem {
                    Position=11,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -10390,12 +10394,12 @@ function Global:Get-OciVmdksByFileSystem {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/fileSystems/$id/vmdks"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/fileSystems/$id/vmdks"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -10411,19 +10415,19 @@ function Global:Get-OciVmdksByFileSystem {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-       
+
             Write-Output $Result
         }
     }
@@ -10437,7 +10441,7 @@ function Global:Get-OciVmdksByFileSystem {
 #>
 function Global:Get-OciTopologyByHost {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -10448,31 +10452,31 @@ function Global:Get-OciTopologyByHost {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/assets/topology/Host/$id"
- 
+
         try {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
 
-        $Topology = ParseTopologies($Result)
-          
+        $Topology = ParseTopologies -Topologies $Result
+
         Write-Output $Topology
     }
 }
@@ -10485,7 +10489,7 @@ function Global:Get-OciTopologyByHost {
 #>
 function Global:Get-OciTopologyByStorage {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -10496,31 +10500,31 @@ function Global:Get-OciTopologyByStorage {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/assets/topology/Storage/$id"
- 
+
         try {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
 
-        $Topology = ParseTopologies($Result)
-          
+        $Topology = ParseTopologies -Topologies $Result
+
         Write-Output $Topology
     }
 }
@@ -10531,7 +10535,7 @@ function Global:Get-OciTopologyByStorage {
     .SYNOPSIS
     Retrieve all hosts
     .DESCRIPTION
-    
+
     .PARAMETER fromTime
     Filter for time range, either in milliseconds or as DateTime
     .PARAMETER toTime
@@ -10571,7 +10575,7 @@ function Global:Get-OciTopologyByStorage {
 #>
 function Global:Get-OciHosts {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                     Position=0,
@@ -10628,7 +10632,7 @@ function Global:Get-OciHosts {
                    Position=17,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -10647,7 +10651,7 @@ function Global:Get-OciHosts {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
@@ -10657,8 +10661,8 @@ function Global:Get-OciHosts {
                 $Limit = 50
             }
 
-            $Uri = $Server.BaseUri + "/rest/v1/assets/hosts"                      
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/hosts"
+
             $Uri += '?'
             $Separator = ''
             if ($fromTime) {
@@ -10684,20 +10688,20 @@ function Global:Get-OciHosts {
             if ($expand) {
                 $Uri += "$($Separator)expand=$expand"
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Hosts = ParseHosts $Result $Server.Timezone
+            $Hosts = ParseHosts -Hosts $Result -Timezone $Server.Timezone
 
             if ($Hosts) { Write-Output $Hosts }
 
@@ -10719,33 +10723,33 @@ function Global:Get-OciHosts {
 #>
 function Global:Get-OciHostCount {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                    Position=5,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/assets/hosts/count"
- 
+
         try {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
 
         Write-Output $Result.Value
@@ -10792,7 +10796,7 @@ function Global:Get-OciHostCount {
 #>
 function Global:Get-OciHost {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -10845,7 +10849,7 @@ function Global:Get-OciHost {
                    Position=5,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -10864,10 +10868,10 @@ function Global:Get-OciHost {
             }
         }
     }
-   
+
     Process {
-        $Uri = $Server.BaseUri + "/rest/v1/assets/hosts/$id"            
- 
+        $Uri = $Server.BaseUri + "/rest/v1/assets/hosts/$id"
+
         if ($fromTime -or $toTime -or $expand) {
             $Uri += '?'
             $Separator = ''
@@ -10883,20 +10887,21 @@ function Global:Get-OciHost {
                 $Uri += "$($Separator)expand=$expand"
             }
         }
- 
+
         try {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-            
-        $Hosts = ParseHosts $Result $Server.Timezone
+
+        $Hosts = ParseHosts -Hosts $Result -Timezone $Server.Timezone
+
         Write-Output $Hosts
     }
 }
@@ -10905,7 +10910,7 @@ function Global:Get-OciHost {
     .SYNOPSIS
     Remove annotations from host
     .DESCRIPTION
-    Remove annotations from host             
+    Remove annotations from host
     .PARAMETER id
     Id of host to remove annotations from
     .PARAMETER Annotations
@@ -10917,7 +10922,7 @@ function Global:Get-OciHost {
 #>
 function Global:Remove-OciAnnotationsByHost {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -10934,40 +10939,40 @@ function Global:Remove-OciAnnotationsByHost {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/assets/hosts/$id/annotations"
 
         if ($definition) {
             $Uri += "?expand=definition"
-        }      
+        }
 
         if (!$Annotations) {
             $Annotations = Get-OciAnnotationsByHost -id $id -definition -Server $Server
         }
- 
+
         try {
             $Body = ConvertTo-Json @($Annotations | ConvertTo-AnnotationValues) -Compress
             Write-Verbose "Body: $Body"
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-           
-        $AnnotationValues = ParseAnnotationValues($Result)
+
+        $AnnotationValues = ParseAnnotationValues -AnnotationValues $Result
         Write-Output $AnnotationValues
     }
 }
@@ -10988,7 +10993,7 @@ function Global:Remove-OciAnnotationsByHost {
 #>
 function Global:Get-OciAnnotationsByHost {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -11005,7 +11010,7 @@ function Global:Get-OciAnnotationsByHost {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -11024,10 +11029,10 @@ function Global:Get-OciAnnotationsByHost {
             }
         }
     }
-   
+
     Process {
-        $Uri = $($Server.BaseUri) + "/rest/v1/assets/hosts/$id/annotations"            
- 
+        $Uri = $($Server.BaseUri) + "/rest/v1/assets/hosts/$id/annotations"
+
         if ($fromTime -or $toTime -or $expand) {
             $Uri += '?'
             $Separator = ''
@@ -11043,20 +11048,20 @@ function Global:Get-OciAnnotationsByHost {
                 $Uri += "$($Separator)expand=$expand"
             }
         }
- 
+
         try {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
 
-        $AnnotationValues = ParseAnnotationValues($Result)
+        $AnnotationValues = ParseAnnotationValues -AnnotationValues $Result
         Write-Output $AnnotationValues
     }
 }
@@ -11065,7 +11070,7 @@ function Global:Get-OciAnnotationsByHost {
     .SYNOPSIS
     Update annotations of host
     .DESCRIPTION
-    Update annotations of host     
+    Update annotations of host
     .PARAMETER id
     Id of host to update
     .PARAMETER annotation
@@ -11075,7 +11080,7 @@ function Global:Get-OciAnnotationsByHost {
 #>
 function Global:Update-OciAnnotationsByHost {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                    Position=0,
@@ -11092,36 +11097,36 @@ function Global:Update-OciAnnotationsByHost {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/assets/hosts/$id/annotations"
 
         if ($expand) {
             $Uri += "?$($Separator)expand=$expand"
         }
- 
+
         try {
             $Body = ConvertTo-Json @($Annotations | ConvertTo-AnnotationValues) -Compress
             Write-Verbose "Body: $Body"
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PUT -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "PUT to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-           
-        $AnnotationValues = ParseAnnotationValues($Result)
+
+        $AnnotationValues = ParseAnnotationValues -AnnotationValues $Result
         Write-Output $AnnotationValues
     }
 }
@@ -11140,7 +11145,7 @@ function Global:Update-OciAnnotationsByHost {
 #>
 function Global:Remove-OciApplicationsByHost {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -11160,7 +11165,7 @@ function Global:Remove-OciApplicationsByHost {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -11179,10 +11184,10 @@ function Global:Remove-OciApplicationsByHost {
             }
         }
     }
-   
+
     Process {
-        $Uri = $Server.BaseUri + "/rest/v1/assets/hosts/$id/applications"            
- 
+        $Uri = $Server.BaseUri + "/rest/v1/assets/hosts/$id/applications"
+
         if ($expand) {
             $Uri += "?expand=$expand"
         }
@@ -11190,22 +11195,22 @@ function Global:Remove-OciApplicationsByHost {
         if (!$Applications) {
             $Applications = Get-OciApplicationsByHost -id $id -Server $Server
         }
- 
+
         try {
             $Body = ConvertTo-Json -InputObject @($Applications) -Compress
             Write-Verbose "Body: $Body"
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
 
-        $Applications = ParseApplications($Result)
+        $Applications = ParseApplications -Applications $Result
         Write-Output $Applications
     }
 }
@@ -11224,7 +11229,7 @@ function Global:Remove-OciApplicationsByHost {
 #>
 function Global:Get-OciApplicationsByHost {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -11241,7 +11246,7 @@ function Global:Get-OciApplicationsByHost {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -11260,27 +11265,27 @@ function Global:Get-OciApplicationsByHost {
             }
         }
     }
-   
+
     Process {
-        $Uri = $Server.BaseUri + "/rest/v1/assets/hosts/$id/applications"            
- 
+        $Uri = $Server.BaseUri + "/rest/v1/assets/hosts/$id/applications"
+
         if ($expand) {
             $Uri += "$($Separator)expand=$expand"
         }
- 
+
         try {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
 
-        $Applications = ParseApplications $Result
+        $Applications = ParseApplications -Applications $Result
         if ($Applications) {
             Write-Output $Applications
         }
@@ -11291,7 +11296,7 @@ function Global:Get-OciApplicationsByHost {
     .SYNOPSIS
     Update Applications of host
     .DESCRIPTION
-    Update Applications of host     
+    Update Applications of host
     .PARAMETER id
     Id of host to update applications of
     .PARAMETER Applications
@@ -11303,7 +11308,7 @@ function Global:Get-OciApplicationsByHost {
 #>
 function Global:Update-OciApplicationsByHost {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -11323,7 +11328,7 @@ function Global:Update-OciApplicationsByHost {
                    Position=4,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -11342,29 +11347,29 @@ function Global:Update-OciApplicationsByHost {
             }
         }
     }
-   
+
     Process {
-        $Uri = $Server.BaseUri + "/rest/v1/assets/hosts/$id/applications"            
- 
+        $Uri = $Server.BaseUri + "/rest/v1/assets/hosts/$id/applications"
+
         if ($expand) {
             $Uri += "$($Separator)expand=$expand"
         }
- 
+
         try {
             $Body = ConvertTo-Json -InputObject @($Applications) -Compress
             Write-Verbose "Body: $Body"
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PATCH -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "PATCH to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-           
-        $Applications = ParseApplications $Result
+
+        $Applications = ParseApplications -Applications $Result
         Write-Output $Applications
     }
 }
@@ -11373,7 +11378,7 @@ function Global:Update-OciApplicationsByHost {
     .SYNOPSIS
     Add application to host
     .DESCRIPTION
-    Add application to host  
+    Add application to host
     .PARAMETER id
     Id of host to application to
     .PARAMETER Application
@@ -11385,7 +11390,7 @@ function Global:Update-OciApplicationsByHost {
 #>
 function Global:Add-OciApplicationByHost {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -11405,7 +11410,7 @@ function Global:Add-OciApplicationByHost {
                    Position=4,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -11424,29 +11429,29 @@ function Global:Add-OciApplicationByHost {
             }
         }
     }
-   
+
     Process {
-        $Uri = $Server.BaseUri + "/rest/v1/assets/hosts/$id/applications"            
- 
+        $Uri = $Server.BaseUri + "/rest/v1/assets/hosts/$id/applications"
+
         if ($expand) {
             $Uri += "$($Separator)expand=$expand"
         }
- 
+
         try {
             $Body = ConvertTo-Json -InputObject $Application -Compress
             Write-Verbose "Body: $Body"
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method POST -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "POST to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
 
-        $Application = ParseApplications $Result
+        $Application = ParseApplications -Applications $Result
         Write-Output $Application
     }
 }
@@ -11467,7 +11472,7 @@ function Global:Add-OciApplicationByHost {
 #>
 function Global:Remove-OciApplicationByHost {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -11487,7 +11492,7 @@ function Global:Remove-OciApplicationByHost {
                    Position=4,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -11506,27 +11511,27 @@ function Global:Remove-OciApplicationByHost {
             }
         }
     }
-   
+
     Process {
-        $Uri = $($Server.BaseUri) + "/rest/v1/assets/hosts/$id/applications/$($Application.id)"            
- 
+        $Uri = $($Server.BaseUri) + "/rest/v1/assets/hosts/$id/applications/$($Application.id)"
+
         if ($expand) {
             $Uri += "$($Separator)expand=$expand"
         }
- 
+
         try {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-           
-        $Applications = ParseApplications $Result
+
+        $Applications = ParseApplications -Applications $Result
         Write-Output $Applications
     }
 }
@@ -11569,7 +11574,7 @@ function Global:Remove-OciApplicationByHost {
 #>
 function Global:Get-OciClusterHostsByHost {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -11622,7 +11627,7 @@ function Global:Get-OciClusterHostsByHost {
                    Position=15,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -11641,12 +11646,12 @@ function Global:Get-OciClusterHostsByHost {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/hosts/$id/clusterHosts"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/hosts/$id/clusterHosts"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -11662,17 +11667,17 @@ function Global:Get-OciClusterHostsByHost {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -11684,7 +11689,7 @@ function Global:Get-OciClusterHostsByHost {
     .SYNOPSIS
     Retrieve the data center of host
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of host to retrieve
     .PARAMETER fromTime
@@ -11696,7 +11701,7 @@ function Global:Get-OciClusterHostsByHost {
 #>
 function Global:Get-OciDataCenterByHost {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -11716,7 +11721,7 @@ function Global:Get-OciDataCenterByHost {
                    Position=4,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -11735,12 +11740,12 @@ function Global:Get-OciDataCenterByHost {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/hosts/$id/dataCenter"                     
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/hosts/$id/dataCenter"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -11756,17 +11761,17 @@ function Global:Get-OciDataCenterByHost {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -11778,7 +11783,7 @@ function Global:Get-OciDataCenterByHost {
     .SYNOPSIS
     Retrieve datasources of a host.
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of host to retrieve datasources for.
     .PARAMETER fromTime
@@ -11806,7 +11811,7 @@ function Global:Get-OciDataCenterByHost {
 #>
 function Global:Get-OciDatasourcesByHost {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -11850,7 +11855,7 @@ function Global:Get-OciDatasourcesByHost {
                    Position=12,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -11869,12 +11874,12 @@ function Global:Get-OciDatasourcesByHost {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/hosts/$id/datasources"                      
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/hosts/$id/datasources"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -11890,17 +11895,17 @@ function Global:Get-OciDatasourcesByHost {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -11912,7 +11917,7 @@ function Global:Get-OciDatasourcesByHost {
     .SYNOPSIS
     Retrieve the file systems of host
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of host to retrieve file systems for
     .PARAMETER fromTime
@@ -11930,7 +11935,7 @@ function Global:Get-OciDatasourcesByHost {
 #>
 function Global:Get-OciFileSystemsByHost {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -11959,7 +11964,7 @@ function Global:Get-OciFileSystemsByHost {
                    Position=7,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -11978,12 +11983,12 @@ function Global:Get-OciFileSystemsByHost {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/hosts/$id/fileSystems"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/hosts/$id/fileSystems"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -11999,17 +12004,17 @@ function Global:Get-OciFileSystemsByHost {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -12021,7 +12026,7 @@ function Global:Get-OciFileSystemsByHost {
     .SYNOPSIS
     Retrieve one host performance
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of host to retrieve
     .PARAMETER fromTime
@@ -12035,7 +12040,7 @@ function Global:Get-OciFileSystemsByHost {
 #>
 function Global:Get-OciHostPerformance {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -12058,7 +12063,7 @@ function Global:Get-OciHostPerformance {
                    Position=5,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -12077,12 +12082,12 @@ function Global:Get-OciHostPerformance {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/hosts/$id/performance"                      
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/hosts/$id/performance"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -12098,20 +12103,20 @@ function Global:Get-OciHostPerformance {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Performance = ParsePerformance($Result,$Server.Timezone)
+            $Performance = ParsePerformance -Performance $Result -Timezone $Server.Timezone
             Write-Output $Performance
         }
     }
@@ -12121,7 +12126,7 @@ function Global:Get-OciHostPerformance {
     .SYNOPSIS
     Retrieve the ports of host
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of host to retrieve
     .PARAMETER fromTime
@@ -12149,7 +12154,7 @@ function Global:Get-OciHostPerformance {
 #>
 function Global:Get-OciPortsByHost {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -12193,7 +12198,7 @@ function Global:Get-OciPortsByHost {
                    Position=12,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -12212,12 +12217,12 @@ function Global:Get-OciPortsByHost {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/hosts/$id/ports"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/hosts/$id/ports"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -12233,17 +12238,17 @@ function Global:Get-OciPortsByHost {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -12255,7 +12260,7 @@ function Global:Get-OciPortsByHost {
     .SYNOPSIS
     Retrieve all storage resources by host
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of host to retrieve storage resources for
     .PARAMETER fromTime
@@ -12281,7 +12286,7 @@ function Global:Get-OciPortsByHost {
 #>
 function Global:Get-OciStorageResourcesByHost {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -12322,7 +12327,7 @@ function Global:Get-OciStorageResourcesByHost {
                    Position=11,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -12341,12 +12346,12 @@ function Global:Get-OciStorageResourcesByHost {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/hosts/$id/storageResources"                      
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/hosts/$id/storageResources"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -12362,17 +12367,17 @@ function Global:Get-OciStorageResourcesByHost {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -12384,7 +12389,7 @@ function Global:Get-OciStorageResourcesByHost {
     .SYNOPSIS
     Retrieve the virtual machines of host
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of host to retrieve virtual machines  for
     .PARAMETER fromTime
@@ -12418,7 +12423,7 @@ function Global:Get-OciStorageResourcesByHost {
 #>
 function Global:Get-OciVirtualMachinesByHost {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -12471,7 +12476,7 @@ function Global:Get-OciVirtualMachinesByHost {
                    Position=15,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -12489,14 +12494,14 @@ function Global:Get-OciVirtualMachinesByHost {
                 }
             }
         }
- 
+
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/assets/hosts/$id/virtualMachines"
-            
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -12512,17 +12517,17 @@ function Global:Get-OciVirtualMachinesByHost {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -12536,7 +12541,7 @@ function Global:Get-OciVirtualMachinesByHost {
     .SYNOPSIS
     Retrieve internal volume
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of internal volume to retrieve
     .PARAMETER fromTime
@@ -12574,7 +12579,7 @@ function Global:Get-OciVirtualMachinesByHost {
 #>
 function Global:Get-OciInternalVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -12633,7 +12638,7 @@ function Global:Get-OciInternalVolume {
                    Position=17,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -12652,12 +12657,12 @@ function Global:Get-OciInternalVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -12673,20 +12678,20 @@ function Global:Get-OciInternalVolume {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $InternalVolume = ParseInternalVolumes $Result $Server.Timezone
+            $InternalVolume = ParseInternalVolumes -InternalVolumes $Result $Server.Timezone
             Write-Output $InternalVolume
         }
     }
@@ -12709,7 +12714,7 @@ function Global:Get-OciInternalVolume {
 }
 ]
 </pre>
-                    
+
     .PARAMETER id
     Id of object to delete
         .PARAMETER definition
@@ -12717,7 +12722,7 @@ function Global:Get-OciInternalVolume {
 #>
 function Global:Remove-OciAnnotationsByInternalVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -12731,7 +12736,7 @@ function Global:Remove-OciAnnotationsByInternalVolume {
                    Position=5,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -12750,12 +12755,12 @@ function Global:Remove-OciAnnotationsByInternalVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id/annotations"
- 
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -12771,21 +12776,21 @@ function Global:Remove-OciAnnotationsByInternalVolume {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -12795,7 +12800,7 @@ function Global:Remove-OciAnnotationsByInternalVolume {
     .SYNOPSIS
     Retrieve annotations for object
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of object to retrieve
     .PARAMETER expand
@@ -12805,7 +12810,7 @@ function Global:Remove-OciAnnotationsByInternalVolume {
 #>
 function Global:Get-OciAnnotationsByInternalVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -12822,7 +12827,7 @@ function Global:Get-OciAnnotationsByInternalVolume {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -12841,12 +12846,12 @@ function Global:Get-OciAnnotationsByInternalVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id/annotations"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id/annotations"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -12862,17 +12867,17 @@ function Global:Get-OciAnnotationsByInternalVolume {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -12897,7 +12902,7 @@ function Global:Get-OciAnnotationsByInternalVolume {
   }
 ]
 </pre>
-            
+
     .PARAMETER id
     Id of object to update
         .PARAMETER definition
@@ -12905,7 +12910,7 @@ function Global:Get-OciAnnotationsByInternalVolume {
 #>
 function Global:Update-OciAnnotationsByInternalVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -12919,7 +12924,7 @@ function Global:Update-OciAnnotationsByInternalVolume {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -12938,12 +12943,12 @@ function Global:Update-OciAnnotationsByInternalVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id/annotations"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id/annotations"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -12959,19 +12964,19 @@ function Global:Update-OciAnnotationsByInternalVolume {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PUT -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "PUT to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -12983,7 +12988,7 @@ function Global:Update-OciAnnotationsByInternalVolume {
     .SYNOPSIS
     Bulk un-assign applications from internal volume
     .DESCRIPTION
-    Bulk un-assign applications from internal volume 
+    Bulk un-assign applications from internal volume
     .PARAMETER id
     Id of internal volume to update
     .PARAMETER computeResources
@@ -12993,7 +12998,7 @@ function Global:Update-OciAnnotationsByInternalVolume {
 #>
 function Global:Remove-OciApplicationsFromInternalVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -13015,7 +13020,7 @@ function Global:Remove-OciApplicationsFromInternalVolume {
                    Position=4,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -13034,30 +13039,30 @@ function Global:Remove-OciApplicationsFromInternalVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id/applications"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id/applications"
+
             if ($expand) {
                 $Uri += "?$($Separator)expand=$expand"
             }
- 
+
             try {
-                $Body = ConvertTo-Json @($applicationId | % { @{id=$_} }) -Compress
+                $Body = ConvertTo-Json @($applicationId | ForEach-Object { @{id=$_} }) -Compress
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-       
+
             Write-Output $Result
         }
     }
@@ -13067,7 +13072,7 @@ function Global:Remove-OciApplicationsFromInternalVolume {
     .SYNOPSIS
     Retrieve the applications of object
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of object to retrieve
     .PARAMETER fromTime
@@ -13083,7 +13088,7 @@ function Global:Remove-OciApplicationsFromInternalVolume {
 #>
 function Global:Get-OciApplicationsByInternalVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -13109,7 +13114,7 @@ function Global:Get-OciApplicationsByInternalVolume {
                    Position=6,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -13128,12 +13133,12 @@ function Global:Get-OciApplicationsByInternalVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id/applications"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id/applications"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -13149,17 +13154,17 @@ function Global:Get-OciApplicationsByInternalVolume {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -13171,7 +13176,7 @@ function Global:Get-OciApplicationsByInternalVolume {
     .SYNOPSIS
     Bulk assign applications to internal volume
     .DESCRIPTION
-    Bulk assign applications to internal volume     
+    Bulk assign applications to internal volume
     .PARAMETER id
     Id of object to update
     .PARAMETER applicationId
@@ -13183,7 +13188,7 @@ function Global:Get-OciApplicationsByInternalVolume {
 #>
 function Global:Add-OciApplicationsToInternalVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -13205,7 +13210,7 @@ function Global:Add-OciApplicationsToInternalVolume {
                    Position=4,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -13224,29 +13229,29 @@ function Global:Add-OciApplicationsToInternalVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         $applicationId = @($applicationId)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id/applications"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id/applications"
+
             if ($expand) {
                 $Uri += "?$($Separator)expand=$expand"
             }
- 
+
             try {
-                $Body = ConvertTo-Json @($applicationId | % { @{id=$_} }) -Compress
+                $Body = ConvertTo-Json @($applicationId | ForEach-Object { @{id=$_} }) -Compress
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PATCH -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "PATCH to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -13265,7 +13270,7 @@ function Global:Add-OciApplicationsToInternalVolume {
     "id":"12345"
 }
 </pre>
-            
+
     .PARAMETER id
     Id of object to update
     .PARAMETER applicationId
@@ -13277,7 +13282,7 @@ function Global:Add-OciApplicationsToInternalVolume {
 #>
 function Global:Update-OciApplicationsByInternalVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -13297,7 +13302,7 @@ function Global:Update-OciApplicationsByInternalVolume {
                    Position=5,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -13316,12 +13321,12 @@ function Global:Update-OciApplicationsByInternalVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id/applications"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id/applications"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -13337,19 +13342,19 @@ function Global:Update-OciApplicationsByInternalVolume {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = "{ `"id`": `"$applicationId`" }"
                     Write-Verbose "Body: $Body"
                     $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method POST -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "POST to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -13373,7 +13378,7 @@ function Global:Update-OciApplicationsByInternalVolume {
 #>
 function Global:Remove-OciApplicationsByInternalVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -13393,7 +13398,7 @@ function Global:Remove-OciApplicationsByInternalVolume {
                    Position=4,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -13412,26 +13417,26 @@ function Global:Remove-OciApplicationsByInternalVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id/applications/$appId"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id/applications/$appId"
+
             if ($expand) {
                 $Uri += "?$($Separator)expand=$expand"
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -13443,7 +13448,7 @@ function Global:Remove-OciApplicationsByInternalVolume {
     .SYNOPSIS
     Retrieve all compute resources for an internal volume
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of internal volume to retrieve compute resources for
     .PARAMETER fromTime
@@ -13465,7 +13470,7 @@ function Global:Remove-OciApplicationsByInternalVolume {
 #>
 function Global:Get-OciComputeResourcesByInternalVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -13500,7 +13505,7 @@ function Global:Get-OciComputeResourcesByInternalVolume {
                    Position=9,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -13519,12 +13524,12 @@ function Global:Get-OciComputeResourcesByInternalVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id/computeResources"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id/computeResources"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -13540,19 +13545,19 @@ function Global:Get-OciComputeResourcesByInternalVolume {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -13562,7 +13567,7 @@ function Global:Get-OciComputeResourcesByInternalVolume {
     .SYNOPSIS
     Retrieve all data stores for an internal volume
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of internal volume to retrieve data stores for
     .PARAMETER fromTime
@@ -13588,7 +13593,7 @@ function Global:Get-OciComputeResourcesByInternalVolume {
 #>
 function Global:Get-OciDataStoresByInternalVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -13629,7 +13634,7 @@ function Global:Get-OciDataStoresByInternalVolume {
                    Position=11,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -13648,12 +13653,12 @@ function Global:Get-OciDataStoresByInternalVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id/dataStores"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id/dataStores"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -13669,17 +13674,17 @@ function Global:Get-OciDataStoresByInternalVolume {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -13691,7 +13696,7 @@ function Global:Get-OciDataStoresByInternalVolume {
     .SYNOPSIS
     Retrieve the datasources for an internal volume
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of internal volume to retrieve datasource for
     .PARAMETER fromTime
@@ -13719,7 +13724,7 @@ function Global:Get-OciDataStoresByInternalVolume {
 #>
 function Global:Get-OciDatasourcesByInternalVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -13763,7 +13768,7 @@ function Global:Get-OciDatasourcesByInternalVolume {
                    Position=12,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -13782,12 +13787,12 @@ function Global:Get-OciDatasourcesByInternalVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id/datasources"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id/datasources"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -13803,20 +13808,20 @@ function Global:Get-OciDatasourcesByInternalVolume {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-            
-            $Datasources = ParseDatasources($Result)
+
+            $Datasources = ParseDatasources -Datasources $Result
             Write-Output $Datasources
         }
     }
@@ -13826,7 +13831,7 @@ function Global:Get-OciDatasourcesByInternalVolume {
     .SYNOPSIS
     Retrieve internal volume performance
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of internal volume to retrieve
     .PARAMETER fromTime
@@ -13840,7 +13845,7 @@ function Global:Get-OciDatasourcesByInternalVolume {
 #>
 function Global:Get-OciInternalVolumePerformance {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -13863,7 +13868,7 @@ function Global:Get-OciInternalVolumePerformance {
                    Position=5,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -13882,12 +13887,12 @@ function Global:Get-OciInternalVolumePerformance {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id/performance"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id/performance"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -13903,20 +13908,20 @@ function Global:Get-OciInternalVolumePerformance {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Performance = ParsePerformance($Result,$Server.Timezone)
+            $Performance = ParsePerformance -Performance $Result -Timezone $Server.Timezone
             Write-Output $Performance
         }
     }
@@ -13926,7 +13931,7 @@ function Global:Get-OciInternalVolumePerformance {
     .SYNOPSIS
     Retrieve qtrees for one internal volume
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of internal volume to retrieve storage qtrees for
     .PARAMETER fromTime
@@ -13950,7 +13955,7 @@ function Global:Get-OciInternalVolumePerformance {
 #>
 function Global:Get-OciQtreesByInternalVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -13988,7 +13993,7 @@ function Global:Get-OciQtreesByInternalVolume {
                    Position=10,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -14007,12 +14012,12 @@ function Global:Get-OciQtreesByInternalVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id/qtrees"          
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id/qtrees"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -14028,20 +14033,20 @@ function Global:Get-OciQtreesByInternalVolume {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Qtrees = ParseQtrees($Result)
+            $Qtrees = ParseQtrees -Qtrees $Result
             Write-Output $Qtrees
         }
     }
@@ -14051,7 +14056,7 @@ function Global:Get-OciQtreesByInternalVolume {
     .SYNOPSIS
     Retrieve all replica source internal volumes for an internal volume
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of internal volume to retrieve replica source internal volumes for
     .PARAMETER fromTime
@@ -14089,7 +14094,7 @@ function Global:Get-OciQtreesByInternalVolume {
 #>
 function Global:Get-OciSourceInternalVolumesByInternalVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -14148,7 +14153,7 @@ function Global:Get-OciSourceInternalVolumesByInternalVolume {
                    Position=17,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -14167,12 +14172,12 @@ function Global:Get-OciSourceInternalVolumesByInternalVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id/replicaSources"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id/replicaSources"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -14188,19 +14193,19 @@ function Global:Get-OciSourceInternalVolumesByInternalVolume {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -14210,7 +14215,7 @@ function Global:Get-OciSourceInternalVolumesByInternalVolume {
     .SYNOPSIS
     Retrieve all storage nodes for an internal volume
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of internal volume to retrieve storage nodes for
     .PARAMETER fromTime
@@ -14238,7 +14243,7 @@ function Global:Get-OciSourceInternalVolumesByInternalVolume {
 #>
 function Global:Get-OciStorageNodesByInternalVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -14282,7 +14287,7 @@ function Global:Get-OciStorageNodesByInternalVolume {
                    Position=12,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -14301,12 +14306,12 @@ function Global:Get-OciStorageNodesByInternalVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id/storageNodes"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id/storageNodes"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -14322,20 +14327,20 @@ function Global:Get-OciStorageNodesByInternalVolume {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $StorageNodes = ParseStorageNodes($Result)
+            $StorageNodes = ParseStorageNodes -StorageNodes $Result
             Write-Output $StorageNodes
         }
     }
@@ -14345,7 +14350,7 @@ function Global:Get-OciStorageNodesByInternalVolume {
     .SYNOPSIS
     Retrieve all volumes for an internal volume
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of internal volume to retrieve volumes for
     .PARAMETER fromTime
@@ -14391,7 +14396,7 @@ function Global:Get-OciStorageNodesByInternalVolume {
 #>
 function Global:Get-OciVolumesByInternalVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -14462,7 +14467,7 @@ function Global:Get-OciVolumesByInternalVolume {
                    Position=4,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -14481,12 +14486,12 @@ function Global:Get-OciVolumesByInternalVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id/volumes"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/internalVolumes/$id/volumes"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -14502,20 +14507,20 @@ function Global:Get-OciVolumesByInternalVolume {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Volues = ParseVolumes($Result)
+            $Volues = ParseVolumes -Volumes $Result
             Write-Output $Volumes
         }
     }
@@ -14527,7 +14532,7 @@ function Global:Get-OciVolumesByInternalVolume {
     .SYNOPSIS
     Retrieve one port
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of port to retrieve
     .PARAMETER expand
@@ -14555,7 +14560,7 @@ function Global:Get-OciVolumesByInternalVolume {
 #>
 function Global:Get-OciPort {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -14599,7 +14604,7 @@ function Global:Get-OciPort {
                    Position=4,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -14618,12 +14623,12 @@ function Global:Get-OciPort {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/ports/$id"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/ports/$id"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -14639,17 +14644,17 @@ function Global:Get-OciPort {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -14674,7 +14679,7 @@ function Global:Get-OciPort {
 }
 ]
 </pre>
-                    
+
     .PARAMETER id
     Id of object to delete
         .PARAMETER definition
@@ -14682,7 +14687,7 @@ function Global:Get-OciPort {
 #>
 function Global:Remove-OciAnnotationsByPort {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -14696,7 +14701,7 @@ function Global:Remove-OciAnnotationsByPort {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -14715,12 +14720,12 @@ function Global:Remove-OciAnnotationsByPort {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/ports/$id/annotations"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/ports/$id/annotations"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -14736,21 +14741,21 @@ function Global:Remove-OciAnnotationsByPort {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-       
+
             Write-Output $Result
         }
     }
@@ -14760,7 +14765,7 @@ function Global:Remove-OciAnnotationsByPort {
     .SYNOPSIS
     Retrieve annotations for object
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of object to retrieve
     .PARAMETER expand
@@ -14770,7 +14775,7 @@ function Global:Remove-OciAnnotationsByPort {
 #>
 function Global:Get-OciAnnotationsByPort {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -14787,7 +14792,7 @@ function Global:Get-OciAnnotationsByPort {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -14806,12 +14811,12 @@ function Global:Get-OciAnnotationsByPort {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/ports/$id/annotations"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/ports/$id/annotations"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -14827,17 +14832,17 @@ function Global:Get-OciAnnotationsByPort {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -14862,7 +14867,7 @@ function Global:Get-OciAnnotationsByPort {
   }
 ]
 </pre>
-            
+
     .PARAMETER id
     Id of object to update
         .PARAMETER definition
@@ -14870,7 +14875,7 @@ function Global:Get-OciAnnotationsByPort {
 #>
 function Global:Update-get-Port {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -14884,7 +14889,7 @@ function Global:Update-get-Port {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -14903,12 +14908,12 @@ function Global:Update-get-Port {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/ports/$id/annotations"                      
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/ports/$id/annotations"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -14924,21 +14929,21 @@ function Global:Update-get-Port {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: "
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PUT -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "PUT to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -14960,7 +14965,7 @@ function Global:Update-get-Port {
     }
 ]
 </pre>
-            
+
     .PARAMETER id
     Id of object to update
         .PARAMETER computeResources
@@ -14970,7 +14975,7 @@ function Global:Update-get-Port {
 #>
 function Global:Bulk-OciUnAssignApplicationsFromAsset {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -14987,7 +14992,7 @@ function Global:Bulk-OciUnAssignApplicationsFromAsset {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -15006,12 +15011,12 @@ function Global:Bulk-OciUnAssignApplicationsFromAsset {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/ports/$id/applications"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/ports/$id/applications"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -15027,18 +15032,18 @@ function Global:Bulk-OciUnAssignApplicationsFromAsset {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 Write-Verbose "Body: "
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -15050,7 +15055,7 @@ function Global:Bulk-OciUnAssignApplicationsFromAsset {
     .SYNOPSIS
     Retrieve the applications of object
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of object to retrieve
     .PARAMETER fromTime
@@ -15066,7 +15071,7 @@ function Global:Bulk-OciUnAssignApplicationsFromAsset {
 #>
 function Global:Get-OciByTypeAndId {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -15092,7 +15097,7 @@ function Global:Get-OciByTypeAndId {
                    Position=6,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -15111,12 +15116,12 @@ function Global:Get-OciByTypeAndId {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/ports/$id/applications"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/ports/$id/applications"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -15132,17 +15137,17 @@ function Global:Get-OciByTypeAndId {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -15166,7 +15171,7 @@ function Global:Get-OciByTypeAndId {
     }
 ]
 </pre>
-            
+
     .PARAMETER id
     Id of object to update
         .PARAMETER computeResources
@@ -15176,7 +15181,7 @@ function Global:Get-OciByTypeAndId {
 #>
 function Global:Bulk-OciAssignApplicationsToAsset {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -15193,7 +15198,7 @@ function Global:Bulk-OciAssignApplicationsToAsset {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -15212,12 +15217,12 @@ function Global:Bulk-OciAssignApplicationsToAsset {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/ports/$id/applications"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/ports/$id/applications"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -15233,19 +15238,19 @@ function Global:Bulk-OciAssignApplicationsToAsset {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PATCH -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "PATCH to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -15264,7 +15269,7 @@ function Global:Bulk-OciAssignApplicationsToAsset {
     "id":"12345"
 }
 </pre>
-            
+
     .PARAMETER id
     Id of object to update
         .PARAMETER computeResources
@@ -15274,7 +15279,7 @@ function Global:Bulk-OciAssignApplicationsToAsset {
 #>
 function Global:Update-OciByTypeAndId {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -15291,7 +15296,7 @@ function Global:Update-OciByTypeAndId {
                    Position=4,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -15310,12 +15315,12 @@ function Global:Update-OciByTypeAndId {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/ports/$id/applications"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/ports/$id/applications"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -15331,19 +15336,19 @@ function Global:Update-OciByTypeAndId {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: "
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method POST -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "POST to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -15355,7 +15360,7 @@ function Global:Update-OciByTypeAndId {
     .SYNOPSIS
     Retrieve connected ports for one port
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of port to retrieve connected port for
     .PARAMETER expand
@@ -15383,7 +15388,7 @@ function Global:Update-OciByTypeAndId {
 #>
 function Global:Get-OciConnectedPortsByPort {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -15427,7 +15432,7 @@ function Global:Get-OciConnectedPortsByPort {
                    Position=12,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -15446,12 +15451,12 @@ function Global:Get-OciConnectedPortsByPort {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/ports/$id/connectedPorts"           
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/ports/$id/connectedPorts"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -15467,17 +15472,17 @@ function Global:Get-OciConnectedPortsByPort {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -15489,7 +15494,7 @@ function Global:Get-OciConnectedPortsByPort {
     .SYNOPSIS
     Retrieve datasources of a port.
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of port to retrieve datasources for.
     .PARAMETER fromTime
@@ -15517,7 +15522,7 @@ function Global:Get-OciConnectedPortsByPort {
 #>
 function Global:Get-OciDatasourcesByPort {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -15561,7 +15566,7 @@ function Global:Get-OciDatasourcesByPort {
                    Position=12,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -15580,12 +15585,12 @@ function Global:Get-OciDatasourcesByPort {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/ports/$id/datasources"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/ports/$id/datasources"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -15601,19 +15606,19 @@ function Global:Get-OciDatasourcesByPort {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -15623,7 +15628,7 @@ function Global:Get-OciDatasourcesByPort {
     .SYNOPSIS
     Retrieve one device for port
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of port to retrieve device
     .PARAMETER expand
@@ -15635,7 +15640,7 @@ function Global:Get-OciDatasourcesByPort {
 #>
 function Global:Get-OciDeviceByPort {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -15655,7 +15660,7 @@ function Global:Get-OciDeviceByPort {
                    Position=4,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -15674,12 +15679,12 @@ function Global:Get-OciDeviceByPort {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/ports/$id/device"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/ports/$id/device"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -15695,19 +15700,19 @@ function Global:Get-OciDeviceByPort {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-       
+
             Write-Output $Result
         }
     }
@@ -15717,7 +15722,7 @@ function Global:Get-OciDeviceByPort {
     .SYNOPSIS
     Retrieve Fabric for port
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of port to retrieve fabric
     .PARAMETER expand
@@ -15733,7 +15738,7 @@ function Global:Get-OciDeviceByPort {
 #>
 function Global:Get-OciFabricsByPort {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -15759,7 +15764,7 @@ function Global:Get-OciFabricsByPort {
                    Position=6,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -15778,12 +15783,12 @@ function Global:Get-OciFabricsByPort {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/ports/$id/fabrics"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/ports/$id/fabrics"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -15799,17 +15804,17 @@ function Global:Get-OciFabricsByPort {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -15821,7 +15826,7 @@ function Global:Get-OciFabricsByPort {
     .SYNOPSIS
     Retrieve one port performance
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of port to retrieve
     .PARAMETER expand
@@ -15835,7 +15840,7 @@ function Global:Get-OciFabricsByPort {
 #>
 function Global:Get-OciPortPerformance {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -15858,7 +15863,7 @@ function Global:Get-OciPortPerformance {
                    Position=4,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -15877,12 +15882,12 @@ function Global:Get-OciPortPerformance {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/assets/ports/$id/performance"
- 
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -15898,20 +15903,20 @@ function Global:Get-OciPortPerformance {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
-            $Performance = ParsePerformance($Result,$Server.Timezone)
+
+            $Performance = ParsePerformance -Performance $Result -Timezone $Server.Timezone
             Write-Output $Performance
         }
     }
@@ -15923,7 +15928,7 @@ function Global:Get-OciPortPerformance {
     .SYNOPSIS
     Retrieve one Qtree
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of qtree to retrieve
     .PARAMETER fromTime
@@ -15947,7 +15952,7 @@ function Global:Get-OciPortPerformance {
 #>
 function Global:Get-OciQtree {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -15985,7 +15990,7 @@ function Global:Get-OciQtree {
                    Position=10,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -16004,12 +16009,12 @@ function Global:Get-OciQtree {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/qtrees/$id"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/qtrees/$id"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -16025,17 +16030,17 @@ function Global:Get-OciQtree {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -16060,7 +16065,7 @@ function Global:Get-OciQtree {
 }
 ]
 </pre>
-                    
+
     .PARAMETER id
     Id of object to delete
         .PARAMETER definition
@@ -16068,7 +16073,7 @@ function Global:Get-OciQtree {
 #>
 function Global:Remove-OciByTypeAndId {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -16082,7 +16087,7 @@ function Global:Remove-OciByTypeAndId {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -16101,12 +16106,12 @@ function Global:Remove-OciByTypeAndId {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/qtrees/$id/annotations"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/qtrees/$id/annotations"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -16122,19 +16127,19 @@ function Global:Remove-OciByTypeAndId {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -16146,7 +16151,7 @@ function Global:Remove-OciByTypeAndId {
     .SYNOPSIS
     Retrieve annotations for object
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of object to retrieve
     .PARAMETER expand
@@ -16156,7 +16161,7 @@ function Global:Remove-OciByTypeAndId {
 #>
 function Global:Get-OciByTypeAndId {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -16173,7 +16178,7 @@ function Global:Get-OciByTypeAndId {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -16192,12 +16197,12 @@ function Global:Get-OciByTypeAndId {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/qtrees/$id/annotations"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/qtrees/$id/annotations"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -16213,19 +16218,19 @@ function Global:Get-OciByTypeAndId {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-          
+
             Write-Output $Result
         }
     }
@@ -16248,7 +16253,7 @@ function Global:Get-OciByTypeAndId {
   }
 ]
 </pre>
-            
+
     .PARAMETER id
     Id of object to update
         .PARAMETER definition
@@ -16256,7 +16261,7 @@ function Global:Get-OciByTypeAndId {
 #>
 function Global:Update-OciByTypeAndId {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -16270,7 +16275,7 @@ function Global:Update-OciByTypeAndId {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -16289,12 +16294,12 @@ function Global:Update-OciByTypeAndId {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/qtrees/$id/annotations"           
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/qtrees/$id/annotations"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -16310,19 +16315,19 @@ function Global:Update-OciByTypeAndId {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PUT -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "PUT to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -16346,7 +16351,7 @@ function Global:Update-OciByTypeAndId {
     }
 ]
 </pre>
-            
+
     .PARAMETER id
     Id of object to update
         .PARAMETER computeResources
@@ -16356,7 +16361,7 @@ function Global:Update-OciByTypeAndId {
 #>
 function Global:Bulk-OciUnAssignApplicationsFromAsset {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -16373,7 +16378,7 @@ function Global:Bulk-OciUnAssignApplicationsFromAsset {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -16392,12 +16397,12 @@ function Global:Bulk-OciUnAssignApplicationsFromAsset {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/qtrees/$id/applications"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/qtrees/$id/applications"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -16413,19 +16418,19 @@ function Global:Bulk-OciUnAssignApplicationsFromAsset {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -16437,7 +16442,7 @@ function Global:Bulk-OciUnAssignApplicationsFromAsset {
     .SYNOPSIS
     Retrieve the applications of object
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of object to retrieve
     .PARAMETER fromTime
@@ -16453,7 +16458,7 @@ function Global:Bulk-OciUnAssignApplicationsFromAsset {
 #>
 function Global:Get-OciByTypeAndId {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -16479,7 +16484,7 @@ function Global:Get-OciByTypeAndId {
                    Position=6,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -16498,12 +16503,12 @@ function Global:Get-OciByTypeAndId {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/qtrees/$id/applications"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/qtrees/$id/applications"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -16519,17 +16524,17 @@ function Global:Get-OciByTypeAndId {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -16553,7 +16558,7 @@ function Global:Get-OciByTypeAndId {
     }
 ]
 </pre>
-            
+
     .PARAMETER id
     Id of object to update
         .PARAMETER computeResources
@@ -16563,7 +16568,7 @@ function Global:Get-OciByTypeAndId {
 #>
 function Global:Bulk-OciAssignApplicationsToAsset {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -16580,7 +16585,7 @@ function Global:Bulk-OciAssignApplicationsToAsset {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -16599,12 +16604,12 @@ function Global:Bulk-OciAssignApplicationsToAsset {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/qtrees/$id/applications"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/qtrees/$id/applications"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -16620,21 +16625,21 @@ function Global:Bulk-OciAssignApplicationsToAsset {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PATCH -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "PATCH to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -16651,7 +16656,7 @@ function Global:Bulk-OciAssignApplicationsToAsset {
     "id":"12345"
 }
 </pre>
-            
+
     .PARAMETER id
     Id of object to update
         .PARAMETER computeResources
@@ -16661,7 +16666,7 @@ function Global:Bulk-OciAssignApplicationsToAsset {
 #>
 function Global:Update-OciByTypeAndId {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -16678,7 +16683,7 @@ function Global:Update-OciByTypeAndId {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -16697,12 +16702,12 @@ function Global:Update-OciByTypeAndId {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/qtrees/$id/applications"                      
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/qtrees/$id/applications"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -16718,19 +16723,19 @@ function Global:Update-OciByTypeAndId {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method POST -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "POST to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -16742,7 +16747,7 @@ function Global:Update-OciByTypeAndId {
     .SYNOPSIS
     Delete application from object
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of object to delete application from
     .PARAMETER appId
@@ -16754,7 +16759,7 @@ function Global:Update-OciByTypeAndId {
 #>
 function Global:Remove-OciByTypeAndId {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -16774,7 +16779,7 @@ function Global:Remove-OciByTypeAndId {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -16793,12 +16798,12 @@ function Global:Remove-OciByTypeAndId {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/qtrees/$id/applications/$appId"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/qtrees/$id/applications/$appId"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -16814,17 +16819,17 @@ function Global:Remove-OciByTypeAndId {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -16836,7 +16841,7 @@ function Global:Remove-OciByTypeAndId {
     .SYNOPSIS
     Retrieve internal volume for given qtree
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of qtree to retrieve internal volume for
     .PARAMETER fromTime
@@ -16874,7 +16879,7 @@ function Global:Remove-OciByTypeAndId {
 #>
 function Global:Get-OciInternalVolumeByQtree {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -16933,7 +16938,7 @@ function Global:Get-OciInternalVolumeByQtree {
                    Position=17,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -16952,12 +16957,12 @@ function Global:Get-OciInternalVolumeByQtree {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/qtrees/$id/internalVolume"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/qtrees/$id/internalVolume"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -16973,19 +16978,19 @@ function Global:Get-OciInternalVolumeByQtree {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -16995,7 +17000,7 @@ function Global:Get-OciInternalVolumeByQtree {
     .SYNOPSIS
     Retrieve shares for one qtree
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of qtree to retrieve shares for
     .PARAMETER fromTime
@@ -17015,7 +17020,7 @@ function Global:Get-OciInternalVolumeByQtree {
 #>
 function Global:Get-OciSharesByQtree {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -17047,7 +17052,7 @@ function Global:Get-OciSharesByQtree {
                    Position=8,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -17066,12 +17071,12 @@ function Global:Get-OciSharesByQtree {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/qtrees/$id/shares"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/qtrees/$id/shares"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -17087,17 +17092,17 @@ function Global:Get-OciSharesByQtree {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -17109,7 +17114,7 @@ function Global:Get-OciSharesByQtree {
     .SYNOPSIS
     Retrieve storage for given qtree
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of qtree to retrieve storage for
     .PARAMETER fromTime
@@ -17151,7 +17156,7 @@ function Global:Get-OciSharesByQtree {
 #>
 function Global:Get-OciStorageByQtree {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -17216,7 +17221,7 @@ function Global:Get-OciStorageByQtree {
                    Position=19,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -17235,12 +17240,12 @@ function Global:Get-OciStorageByQtree {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/qtrees/$id/storage"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/qtrees/$id/storage"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -17256,20 +17261,20 @@ function Global:Get-OciStorageByQtree {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Storage = ParseStorages $Result $Server.Timezone
+            $Storage = ParseStorages -Storages $Result $Server.Timezone
             Write-Output $Storage
         }
     }
@@ -17279,7 +17284,7 @@ function Global:Get-OciStorageByQtree {
     .SYNOPSIS
     Retrieve volumes for one qtree
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of qtree to retrieve volumes for
     .PARAMETER fromTime
@@ -17325,7 +17330,7 @@ function Global:Get-OciStorageByQtree {
 #>
 function Global:Get-OciVolumesByQtree {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -17396,7 +17401,7 @@ function Global:Get-OciVolumesByQtree {
                    Position=21,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -17415,12 +17420,12 @@ function Global:Get-OciVolumesByQtree {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/qtrees/$id/volumes"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/qtrees/$id/volumes"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -17436,20 +17441,20 @@ function Global:Get-OciVolumesByQtree {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Volumes = ParseVolumes($Result)
+            $Volumes = ParseVolumes -Volumes $Result
             Write-Output $Volumes
         }
     }
@@ -17461,7 +17466,7 @@ function Global:Get-OciVolumesByQtree {
     .SYNOPSIS
     Retrieve one Share
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of share to retrieve
     .PARAMETER fromTime
@@ -17481,7 +17486,7 @@ function Global:Get-OciVolumesByQtree {
 #>
 function Global:Get-OciShare {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -17513,7 +17518,7 @@ function Global:Get-OciShare {
                    Position=8,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -17532,12 +17537,12 @@ function Global:Get-OciShare {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/shares/$id"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/shares/$id"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -17553,17 +17558,17 @@ function Global:Get-OciShare {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -17588,7 +17593,7 @@ function Global:Get-OciShare {
 }
 ]
 </pre>
-                    
+
     .PARAMETER id
     Id of object to delete
         .PARAMETER definition
@@ -17596,7 +17601,7 @@ function Global:Get-OciShare {
 #>
 function Global:Remove-OciByTypeAndId {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -17610,7 +17615,7 @@ function Global:Remove-OciByTypeAndId {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -17629,12 +17634,12 @@ function Global:Remove-OciByTypeAndId {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/shares/$id/annotations"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/shares/$id/annotations"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -17650,21 +17655,21 @@ function Global:Remove-OciByTypeAndId {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -17674,7 +17679,7 @@ function Global:Remove-OciByTypeAndId {
     .SYNOPSIS
     Retrieve annotations for object
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of object to retrieve
     .PARAMETER expand
@@ -17684,7 +17689,7 @@ function Global:Remove-OciByTypeAndId {
 #>
 function Global:Get-OciByTypeAndId {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -17701,7 +17706,7 @@ function Global:Get-OciByTypeAndId {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -17720,12 +17725,12 @@ function Global:Get-OciByTypeAndId {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/shares/$id/annotations"                      
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/shares/$id/annotations"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -17741,17 +17746,17 @@ function Global:Get-OciByTypeAndId {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -17776,7 +17781,7 @@ function Global:Get-OciByTypeAndId {
   }
 ]
 </pre>
-            
+
     .PARAMETER id
     Id of object to update
         .PARAMETER definition
@@ -17784,7 +17789,7 @@ function Global:Get-OciByTypeAndId {
 #>
 function Global:Update-OciByTypeAndId {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -17798,7 +17803,7 @@ function Global:Update-OciByTypeAndId {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -17817,12 +17822,12 @@ function Global:Update-OciByTypeAndId {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/shares/$id/annotations"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/shares/$id/annotations"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -17838,19 +17843,19 @@ function Global:Update-OciByTypeAndId {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PUT -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "PUT to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -17874,7 +17879,7 @@ function Global:Update-OciByTypeAndId {
     }
 ]
 </pre>
-            
+
     .PARAMETER id
     Id of object to update
         .PARAMETER computeResources
@@ -17884,7 +17889,7 @@ function Global:Update-OciByTypeAndId {
 #>
 function Global:Bulk-OciUnAssignApplicationsFromAsset {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -17901,7 +17906,7 @@ function Global:Bulk-OciUnAssignApplicationsFromAsset {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -17920,12 +17925,12 @@ function Global:Bulk-OciUnAssignApplicationsFromAsset {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/shares/$id/applications"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/shares/$id/applications"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -17941,19 +17946,19 @@ function Global:Bulk-OciUnAssignApplicationsFromAsset {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -17965,7 +17970,7 @@ function Global:Bulk-OciUnAssignApplicationsFromAsset {
     .SYNOPSIS
     Retrieve the applications of object
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of object to retrieve
     .PARAMETER fromTime
@@ -17981,7 +17986,7 @@ function Global:Bulk-OciUnAssignApplicationsFromAsset {
 #>
 function Global:Get-OciByTypeAndId {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -18007,7 +18012,7 @@ function Global:Get-OciByTypeAndId {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -18026,12 +18031,12 @@ function Global:Get-OciByTypeAndId {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/shares/$id/applications"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/shares/$id/applications"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -18047,17 +18052,17 @@ function Global:Get-OciByTypeAndId {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -18081,7 +18086,7 @@ function Global:Get-OciByTypeAndId {
     }
 ]
 </pre>
-            
+
     .PARAMETER id
     Id of object to update
         .PARAMETER computeResources
@@ -18091,7 +18096,7 @@ function Global:Get-OciByTypeAndId {
 #>
 function Global:Bulk-OciAssignApplicationsToAsset {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -18108,7 +18113,7 @@ function Global:Bulk-OciAssignApplicationsToAsset {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -18127,12 +18132,12 @@ function Global:Bulk-OciAssignApplicationsToAsset {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/shares/$id/applications"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/shares/$id/applications"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -18148,21 +18153,21 @@ function Global:Bulk-OciAssignApplicationsToAsset {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PATCH -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "PATCH to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -18179,7 +18184,7 @@ function Global:Bulk-OciAssignApplicationsToAsset {
     "id":"12345"
 }
 </pre>
-            
+
     .PARAMETER id
     Id of object to update
         .PARAMETER computeResources
@@ -18189,7 +18194,7 @@ function Global:Bulk-OciAssignApplicationsToAsset {
 #>
 function Global:Update-OciByTypeAndId {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -18206,7 +18211,7 @@ function Global:Update-OciByTypeAndId {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -18225,12 +18230,12 @@ function Global:Update-OciByTypeAndId {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/shares/$id/applications"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/shares/$id/applications"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -18246,19 +18251,19 @@ function Global:Update-OciByTypeAndId {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method POST -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "POST to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -18270,7 +18275,7 @@ function Global:Update-OciByTypeAndId {
     .SYNOPSIS
     Delete application from object
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of object to delete application from
     .PARAMETER appId
@@ -18282,7 +18287,7 @@ function Global:Update-OciByTypeAndId {
 #>
 function Global:Remove-OciByTypeAndId {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -18302,7 +18307,7 @@ function Global:Remove-OciByTypeAndId {
                    Position=4,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -18321,12 +18326,12 @@ function Global:Remove-OciByTypeAndId {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/shares/$id/applications/{appId}"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/shares/$id/applications/{appId}"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -18342,17 +18347,17 @@ function Global:Remove-OciByTypeAndId {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -18364,7 +18369,7 @@ function Global:Remove-OciByTypeAndId {
     .SYNOPSIS
     Retrieve qtree for given share
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of share to retrieve qtree for
     .PARAMETER fromTime
@@ -18388,7 +18393,7 @@ function Global:Remove-OciByTypeAndId {
 #>
 function Global:Get-OciQtree {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -18426,7 +18431,7 @@ function Global:Get-OciQtree {
                    Position=10,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -18445,12 +18450,12 @@ function Global:Get-OciQtree {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/shares/$id/qtree"                      
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/shares/$id/qtree"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -18466,17 +18471,17 @@ function Global:Get-OciQtree {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -18530,7 +18535,7 @@ function Global:Get-OciQtree {
 #>
 function Global:Get-OciStorageByShare {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -18595,7 +18600,7 @@ function Global:Get-OciStorageByShare {
                    Position=19,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -18614,12 +18619,12 @@ function Global:Get-OciStorageByShare {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/shares/$id/storage"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/shares/$id/storage"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -18635,17 +18640,17 @@ function Global:Get-OciStorageByShare {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -18659,7 +18664,7 @@ function Global:Get-OciStorageByShare {
     .SYNOPSIS
     Retrieve one storage node
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of storage node to retrieve
     .PARAMETER fromTime
@@ -18687,7 +18692,7 @@ function Global:Get-OciStorageByShare {
 #>
 function Global:Get-OciStorageNode {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -18731,7 +18736,7 @@ function Global:Get-OciStorageNode {
                    Position=12,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -18750,12 +18755,12 @@ function Global:Get-OciStorageNode {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storageNodes/$id"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storageNodes/$id"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -18771,20 +18776,20 @@ function Global:Get-OciStorageNode {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $StorageNodes = ParseStorageNodes($Result)
+            $StorageNodes = ParseStorageNodes -StorageNodes $Result
             Write-Output $StorageNodes
         }
     }
@@ -18807,7 +18812,7 @@ function Global:Get-OciStorageNode {
 }
 ]
 </pre>
-                    
+
     .PARAMETER id
     Id of object to delete
         .PARAMETER definition
@@ -18815,7 +18820,7 @@ function Global:Get-OciStorageNode {
 #>
 function Global:Remove-OciAnnotationsByStorageNode {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -18829,7 +18834,7 @@ function Global:Remove-OciAnnotationsByStorageNode {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -18848,12 +18853,12 @@ function Global:Remove-OciAnnotationsByStorageNode {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storageNodes/$id/annotations"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storageNodes/$id/annotations"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -18869,19 +18874,19 @@ function Global:Remove-OciAnnotationsByStorageNode {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -18893,7 +18898,7 @@ function Global:Remove-OciAnnotationsByStorageNode {
     .SYNOPSIS
     Retrieve annotations for object
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of object to retrieve
     .PARAMETER expand
@@ -18903,7 +18908,7 @@ function Global:Remove-OciAnnotationsByStorageNode {
 #>
 function Global:Get-OciAnnotationsByStorageNode {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -18920,7 +18925,7 @@ function Global:Get-OciAnnotationsByStorageNode {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -18939,12 +18944,12 @@ function Global:Get-OciAnnotationsByStorageNode {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storageNodes/$id/annotations"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storageNodes/$id/annotations"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -18960,19 +18965,19 @@ function Global:Get-OciAnnotationsByStorageNode {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-       
+
             Write-Output $Result
         }
     }
@@ -18995,7 +19000,7 @@ function Global:Get-OciAnnotationsByStorageNode {
   }
 ]
 </pre>
-            
+
     .PARAMETER id
     Id of object to update
         .PARAMETER definition
@@ -19003,7 +19008,7 @@ function Global:Get-OciAnnotationsByStorageNode {
 #>
 function Global:Update-OciAnnotationsByStorageNode {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -19017,7 +19022,7 @@ function Global:Update-OciAnnotationsByStorageNode {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -19036,12 +19041,12 @@ function Global:Update-OciAnnotationsByStorageNode {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storageNodes/$id/annotations"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storageNodes/$id/annotations"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -19057,19 +19062,19 @@ function Global:Update-OciAnnotationsByStorageNode {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PUT -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "PUT to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -19081,7 +19086,7 @@ function Global:Update-OciAnnotationsByStorageNode {
     .SYNOPSIS
     Retrieve one storage node datasources
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of storage node to retrieve datasources for
     .PARAMETER fromTime
@@ -19109,7 +19114,7 @@ function Global:Update-OciAnnotationsByStorageNode {
 #>
 function Global:Get-OciDatasourcesByStorageNode {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -19153,7 +19158,7 @@ function Global:Get-OciDatasourcesByStorageNode {
                    Position=12,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -19172,12 +19177,12 @@ function Global:Get-OciDatasourcesByStorageNode {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storageNodes/$id/datasources"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storageNodes/$id/datasources"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -19193,17 +19198,17 @@ function Global:Get-OciDatasourcesByStorageNode {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -19215,7 +19220,7 @@ function Global:Get-OciDatasourcesByStorageNode {
     .SYNOPSIS
     Retrieve one storage node performance
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of storage node to retrieve
     .PARAMETER fromTime
@@ -19229,7 +19234,7 @@ function Global:Get-OciDatasourcesByStorageNode {
 #>
 function Global:Get-OciStorageNodePerformance {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -19252,7 +19257,7 @@ function Global:Get-OciStorageNodePerformance {
                    Position=5,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -19271,12 +19276,12 @@ function Global:Get-OciStorageNodePerformance {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storageNodes/$id/performance"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storageNodes/$id/performance"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -19292,20 +19297,20 @@ function Global:Get-OciStorageNodePerformance {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Performance = ParsePerformance($Result,$Server.Timezone)
+            $Performance = ParsePerformance -Performance $Result -Timezone $Server.Timezone
             Write-Output $Performance
         }
     }
@@ -19315,7 +19320,7 @@ function Global:Get-OciStorageNodePerformance {
     .SYNOPSIS
     Retrieve all ports by node
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of storage node to retrieve ports for
     .PARAMETER fromTime
@@ -19343,7 +19348,7 @@ function Global:Get-OciStorageNodePerformance {
 #>
 function Global:Get-OciPortsByStorageNode {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -19387,7 +19392,7 @@ function Global:Get-OciPortsByStorageNode {
                    Position=12,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -19406,12 +19411,12 @@ function Global:Get-OciPortsByStorageNode {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storageNodes/$id/ports"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storageNodes/$id/ports"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -19427,17 +19432,17 @@ function Global:Get-OciPortsByStorageNode {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -19449,7 +19454,7 @@ function Global:Get-OciPortsByStorageNode {
     .SYNOPSIS
     Retrieve all storage pools by node
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of storage node to retrieve storage pool for
     .PARAMETER fromTime
@@ -19481,7 +19486,7 @@ function Global:Get-OciPortsByStorageNode {
 #>
 function Global:Get-OciStoragePoolsByNode {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -19531,7 +19536,7 @@ function Global:Get-OciStoragePoolsByNode {
                    Position=14,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -19550,12 +19555,12 @@ function Global:Get-OciStoragePoolsByNode {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storageNodes/$id/storagePools"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storageNodes/$id/storagePools"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -19571,19 +19576,19 @@ function Global:Get-OciStoragePoolsByNode {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -19595,7 +19600,7 @@ function Global:Get-OciStoragePoolsByNode {
     .SYNOPSIS
     Retrieve one storage pool
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of storage pool to retrieve
     .PARAMETER fromTime
@@ -19627,7 +19632,7 @@ function Global:Get-OciStoragePoolsByNode {
 #>
 function Global:Get-OciStoragePool {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -19677,7 +19682,7 @@ function Global:Get-OciStoragePool {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -19696,12 +19701,12 @@ function Global:Get-OciStoragePool {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storagePools/$id"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storagePools/$id"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -19717,17 +19722,17 @@ function Global:Get-OciStoragePool {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -19752,7 +19757,7 @@ function Global:Get-OciStoragePool {
 }
 ]
 </pre>
-                    
+
     .PARAMETER id
     Id of object to delete
         .PARAMETER definition
@@ -19760,7 +19765,7 @@ function Global:Get-OciStoragePool {
 #>
 function Global:Remove-OciAnnotationsByStoragePool {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -19774,7 +19779,7 @@ function Global:Remove-OciAnnotationsByStoragePool {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -19793,12 +19798,12 @@ function Global:Remove-OciAnnotationsByStoragePool {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storagePools/$id/annotations"                       
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storagePools/$id/annotations"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -19814,21 +19819,21 @@ function Global:Remove-OciAnnotationsByStoragePool {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: "
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -19838,7 +19843,7 @@ function Global:Remove-OciAnnotationsByStoragePool {
     .SYNOPSIS
     Retrieve annotations for object
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of object to retrieve
     .PARAMETER expand
@@ -19848,7 +19853,7 @@ function Global:Remove-OciAnnotationsByStoragePool {
 #>
 function Global:Get-OciAnnotationsByStoragePool {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -19865,7 +19870,7 @@ function Global:Get-OciAnnotationsByStoragePool {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -19884,12 +19889,12 @@ function Global:Get-OciAnnotationsByStoragePool {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storagePools/$id/annotations"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storagePools/$id/annotations"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -19905,19 +19910,19 @@ function Global:Get-OciAnnotationsByStoragePool {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -19940,7 +19945,7 @@ function Global:Get-OciAnnotationsByStoragePool {
   }
 ]
 </pre>
-            
+
     .PARAMETER id
     Id of object to update
         .PARAMETER definition
@@ -19948,7 +19953,7 @@ function Global:Get-OciAnnotationsByStoragePool {
 #>
 function Global:Update-OciAnnotationsByStoragePool {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -19962,7 +19967,7 @@ function Global:Update-OciAnnotationsByStoragePool {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -19981,12 +19986,12 @@ function Global:Update-OciAnnotationsByStoragePool {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storagePools/$id/annotations"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storagePools/$id/annotations"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -20002,19 +20007,19 @@ function Global:Update-OciAnnotationsByStoragePool {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PUT -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "PUT to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -20026,7 +20031,7 @@ function Global:Update-OciAnnotationsByStoragePool {
     .SYNOPSIS
     Retrieve one storage pool datasources
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of storage pool to retrieve datasources for
     .PARAMETER fromTime
@@ -20054,7 +20059,7 @@ function Global:Update-OciAnnotationsByStoragePool {
 #>
 function Global:Get-OciDatasourcesByStoragePool {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -20098,7 +20103,7 @@ function Global:Get-OciDatasourcesByStoragePool {
                    Position=12,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -20117,12 +20122,12 @@ function Global:Get-OciDatasourcesByStoragePool {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storagePools/$id/datasources"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storagePools/$id/datasources"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -20138,17 +20143,17 @@ function Global:Get-OciDatasourcesByStoragePool {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -20160,7 +20165,7 @@ function Global:Get-OciDatasourcesByStoragePool {
     .SYNOPSIS
     Retrieve Disks for storage pool
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of storage pool to retrieve disks for
     .PARAMETER fromTime
@@ -20188,7 +20193,7 @@ function Global:Get-OciDatasourcesByStoragePool {
 #>
 function Global:Get-OciDisksByStoragePool {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -20232,7 +20237,7 @@ function Global:Get-OciDisksByStoragePool {
                    Position=12,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -20251,12 +20256,12 @@ function Global:Get-OciDisksByStoragePool {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/assets/storagePools/$id/disks"
- 
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -20272,17 +20277,17 @@ function Global:Get-OciDisksByStoragePool {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -20294,7 +20299,7 @@ function Global:Get-OciDisksByStoragePool {
     .SYNOPSIS
     Retrieve internal volumes for storage pool
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of storage pool to retrieve internal volumes for
     .PARAMETER fromTime
@@ -20332,7 +20337,7 @@ function Global:Get-OciDisksByStoragePool {
 #>
 function Global:Get-OciInternalVolumesByStoragePool {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -20391,7 +20396,7 @@ function Global:Get-OciInternalVolumesByStoragePool {
                    Position=17,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -20410,12 +20415,12 @@ function Global:Get-OciInternalVolumesByStoragePool {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storagePools/$id/internalVolumes"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storagePools/$id/internalVolumes"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -20431,17 +20436,17 @@ function Global:Get-OciInternalVolumesByStoragePool {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -20453,7 +20458,7 @@ function Global:Get-OciInternalVolumesByStoragePool {
     .SYNOPSIS
     Retrieve one storage pool performance
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of storage pool to retrieve
     .PARAMETER fromTime
@@ -20467,7 +20472,7 @@ function Global:Get-OciInternalVolumesByStoragePool {
 #>
 function Global:Get-OciStoragePoolPerformance {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -20490,7 +20495,7 @@ function Global:Get-OciStoragePoolPerformance {
                    Position=5,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -20509,12 +20514,12 @@ function Global:Get-OciStoragePoolPerformance {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storagePools/$id/performance"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storagePools/$id/performance"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -20530,20 +20535,20 @@ function Global:Get-OciStoragePoolPerformance {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Performance = ParsePerformance($Result,$Server.Timezone)
+            $Performance = ParsePerformance -Performance $Result -Timezone $Server.Timezone
             Write-Output $Performance
         }
     }
@@ -20553,7 +20558,7 @@ function Global:Get-OciStoragePoolPerformance {
     .SYNOPSIS
     Retrieve one storage pool storage
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of storage pool to retrieve storage for
     .PARAMETER fromTime
@@ -20595,7 +20600,7 @@ function Global:Get-OciStoragePoolPerformance {
 #>
 function Global:Get-OciStorageByStoragePool {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -20660,7 +20665,7 @@ function Global:Get-OciStorageByStoragePool {
                    Position=19,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -20679,12 +20684,12 @@ function Global:Get-OciStorageByStoragePool {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storagePools/$id/storage"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storagePools/$id/storage"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -20700,19 +20705,19 @@ function Global:Get-OciStorageByStoragePool {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -20722,7 +20727,7 @@ function Global:Get-OciStorageByStoragePool {
     .SYNOPSIS
     Retrieve storage nodes for storage pool
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of storage pool to retrieve storage nodes for
     .PARAMETER fromTime
@@ -20750,7 +20755,7 @@ function Global:Get-OciStorageByStoragePool {
 #>
 function Global:Get-OciStorageNodesByStoragePool {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -20794,7 +20799,7 @@ function Global:Get-OciStorageNodesByStoragePool {
                    Position=12,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -20813,12 +20818,12 @@ function Global:Get-OciStorageNodesByStoragePool {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storagePools/$id/storageNodes"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storagePools/$id/storageNodes"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -20834,17 +20839,17 @@ function Global:Get-OciStorageNodesByStoragePool {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -20856,7 +20861,7 @@ function Global:Get-OciStorageNodesByStoragePool {
     .SYNOPSIS
     Retrieve resources for storage pool
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of storage pool to retrieve resources for
     .PARAMETER fromTime
@@ -20882,7 +20887,7 @@ function Global:Get-OciStorageNodesByStoragePool {
 #>
 function Global:Get-OciStorageResourcesByStoragePool {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -20923,7 +20928,7 @@ function Global:Get-OciStorageResourcesByStoragePool {
                    Position=11,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -20942,12 +20947,12 @@ function Global:Get-OciStorageResourcesByStoragePool {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storagePools/$id/storageResources"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storagePools/$id/storageResources"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -20963,17 +20968,17 @@ function Global:Get-OciStorageResourcesByStoragePool {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -20985,7 +20990,7 @@ function Global:Get-OciStorageResourcesByStoragePool {
     .SYNOPSIS
     Retrieve volumes for storage pool
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of storage pool to retrieve volumes for
     .PARAMETER fromTime
@@ -21031,7 +21036,7 @@ function Global:Get-OciStorageResourcesByStoragePool {
 #>
 function Global:Get-OciVolumesByStoragePool {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -21102,7 +21107,7 @@ function Global:Get-OciVolumesByStoragePool {
                    Position=21,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -21121,12 +21126,12 @@ function Global:Get-OciVolumesByStoragePool {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/assets/storagePools/$id/volumes"
- 
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -21142,20 +21147,20 @@ function Global:Get-OciVolumesByStoragePool {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Volumes = ParseVolumes($Result)
+            $Volumes = ParseVolumes -Volumes $Result
             Write-Output $Volumes
         }
     }
@@ -21213,7 +21218,7 @@ function Global:Get-OciVolumesByStoragePool {
 #>
 function Global:Get-OciStorages {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                     Position=0,
@@ -21282,7 +21287,7 @@ function Global:Get-OciStorages {
                    Position=22,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -21301,7 +21306,7 @@ function Global:Get-OciStorages {
             }
         }
     }
-   
+
     Process {
         # OCI allows to only fetch maximum 50 items, thus we need to repeat the command if no limit is specified to fetch all items
         if ($Limit -eq 0) {
@@ -21309,8 +21314,8 @@ function Global:Get-OciStorages {
             $Limit = 50
         }
 
-        $Uri = $Server.BaseUri + "/rest/v1/assets/storages"                  
- 
+        $Uri = $Server.BaseUri + "/rest/v1/assets/storages"
+
         $Uri += '?'
         $Separator = ''
         if ($fromTime) {
@@ -21336,20 +21341,20 @@ function Global:Get-OciStorages {
         if ($expand) {
             $Uri += "$($Separator)expand=$expand"
         }
- 
+
         try {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-       
-        $Storages = ParseStorages($Result)
+
+        $Storages = ParseStorages -Storages $Result
         if ($Storages) { Write-Output $Storages }
 
         if ($FetchAll -and @($Storages).Count -eq $Limit) {
@@ -21363,40 +21368,40 @@ function Global:Get-OciStorages {
     .SYNOPSIS
     Retrieve total count of storages.
     .DESCRIPTION
-    
+
 
 #>
 function Global:Get-OciStorageCount {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                    Position=0,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/assets/storages/count"
- 
+
             try {
                     $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -21408,7 +21413,7 @@ function Global:Get-OciStorageCount {
     .SYNOPSIS
     Retrieve one storage
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of storage to retrieve
     .PARAMETER fromTime
@@ -21450,7 +21455,7 @@ function Global:Get-OciStorageCount {
 #>
 function Global:Get-OciStorage {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -21515,7 +21520,7 @@ function Global:Get-OciStorage {
                    Position=19,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -21534,10 +21539,10 @@ function Global:Get-OciStorage {
             }
         }
     }
-   
+
     Process {
-        $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id"            
- 
+        $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id"
+
         if ($fromTime -or $toTime -or $expand) {
             $Uri += '?'
             $Separator = ''
@@ -21553,20 +21558,20 @@ function Global:Get-OciStorage {
                 $Uri += "$($Separator)expand=$expand"
             }
         }
- 
+
         try {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
 
-        $Storage = ParseStorages $Result $Server.Timezone
+        $Storage = ParseStorages -Storages $Result $Server.Timezone
         Write-Output $Storage
     }
 }
@@ -21588,7 +21593,7 @@ function Global:Get-OciStorage {
 }
 ]
 </pre>
-                    
+
     .PARAMETER id
     Id of object to delete
         .PARAMETER definition
@@ -21596,7 +21601,7 @@ function Global:Get-OciStorage {
 #>
 function Global:Remove-OciAnnotationsByStorage {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -21610,7 +21615,7 @@ function Global:Remove-OciAnnotationsByStorage {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -21629,12 +21634,12 @@ function Global:Remove-OciAnnotationsByStorage {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/annotations"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/annotations"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -21650,19 +21655,19 @@ function Global:Remove-OciAnnotationsByStorage {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -21674,7 +21679,7 @@ function Global:Remove-OciAnnotationsByStorage {
     .SYNOPSIS
     Retrieve annotations for object
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of object to retrieve
     .PARAMETER expand
@@ -21684,7 +21689,7 @@ function Global:Remove-OciAnnotationsByStorage {
 #>
 function Global:Get-OciAnnotationsByStorage {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -21701,7 +21706,7 @@ function Global:Get-OciAnnotationsByStorage {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -21720,12 +21725,12 @@ function Global:Get-OciAnnotationsByStorage {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/annotations"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/annotations"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -21741,17 +21746,17 @@ function Global:Get-OciAnnotationsByStorage {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -21776,7 +21781,7 @@ function Global:Get-OciAnnotationsByStorage {
   }
 ]
 </pre>
-            
+
     .PARAMETER id
     Id of object to update
         .PARAMETER definition
@@ -21784,7 +21789,7 @@ function Global:Get-OciAnnotationsByStorage {
 #>
 function Global:Update-OciAnnotationsByStorage {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -21798,7 +21803,7 @@ function Global:Update-OciAnnotationsByStorage {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -21817,12 +21822,12 @@ function Global:Update-OciAnnotationsByStorage {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/annotations"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/annotations"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -21838,19 +21843,19 @@ function Global:Update-OciAnnotationsByStorage {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PUT -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "PUT to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -21874,7 +21879,7 @@ function Global:Update-OciAnnotationsByStorage {
     }
 ]
 </pre>
-            
+
     .PARAMETER id
     Id of object to update
         .PARAMETER computeResources
@@ -21884,7 +21889,7 @@ function Global:Update-OciAnnotationsByStorage {
 #>
 function Global:Bulk-OciUnAssignApplicationsFromAsset {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -21901,7 +21906,7 @@ function Global:Bulk-OciUnAssignApplicationsFromAsset {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -21920,12 +21925,12 @@ function Global:Bulk-OciUnAssignApplicationsFromAsset {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/applications"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/applications"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -21941,19 +21946,19 @@ function Global:Bulk-OciUnAssignApplicationsFromAsset {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: "
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -21965,7 +21970,7 @@ function Global:Bulk-OciUnAssignApplicationsFromAsset {
     .SYNOPSIS
     Retrieve the applications of object
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of object to retrieve
     .PARAMETER fromTime
@@ -21981,7 +21986,7 @@ function Global:Bulk-OciUnAssignApplicationsFromAsset {
 #>
 function Global:Get-OciByTypeAndId {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -22007,7 +22012,7 @@ function Global:Get-OciByTypeAndId {
                    Position=6,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -22026,12 +22031,12 @@ function Global:Get-OciByTypeAndId {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/applications"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/applications"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -22047,17 +22052,17 @@ function Global:Get-OciByTypeAndId {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -22081,7 +22086,7 @@ function Global:Get-OciByTypeAndId {
     }
 ]
 </pre>
-            
+
     .PARAMETER id
     Id of object to update
         .PARAMETER computeResources
@@ -22091,7 +22096,7 @@ function Global:Get-OciByTypeAndId {
 #>
 function Global:Bulk-OciAssignApplicationsToAsset {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -22108,7 +22113,7 @@ function Global:Bulk-OciAssignApplicationsToAsset {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -22127,12 +22132,12 @@ function Global:Bulk-OciAssignApplicationsToAsset {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/applications"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/applications"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -22148,19 +22153,19 @@ function Global:Bulk-OciAssignApplicationsToAsset {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PATCH -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "PATCH to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -22179,7 +22184,7 @@ function Global:Bulk-OciAssignApplicationsToAsset {
     "id":"12345"
 }
 </pre>
-            
+
     .PARAMETER id
     Id of object to update
         .PARAMETER computeResources
@@ -22189,7 +22194,7 @@ function Global:Bulk-OciAssignApplicationsToAsset {
 #>
 function Global:Update-OciByTypeAndId {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -22206,7 +22211,7 @@ function Global:Update-OciByTypeAndId {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -22225,12 +22230,12 @@ function Global:Update-OciByTypeAndId {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/applications"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/applications"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -22246,21 +22251,21 @@ function Global:Update-OciByTypeAndId {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method POST -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "POST to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -22270,7 +22275,7 @@ function Global:Update-OciByTypeAndId {
     .SYNOPSIS
     Retrieve datasources of a storage.
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of storage to retrieve datasources for.
     .PARAMETER fromTime
@@ -22298,7 +22303,7 @@ function Global:Update-OciByTypeAndId {
 #>
 function Global:Get-OciDatasourcesByStorage {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -22342,7 +22347,7 @@ function Global:Get-OciDatasourcesByStorage {
                    Position=12,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -22361,12 +22366,12 @@ function Global:Get-OciDatasourcesByStorage {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/datasources"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/datasources"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -22382,19 +22387,19 @@ function Global:Get-OciDatasourcesByStorage {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-       
+
             Write-Output $Result
         }
     }
@@ -22404,7 +22409,7 @@ function Global:Get-OciDatasourcesByStorage {
     .SYNOPSIS
     Retrieve disks for one storage
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of storage to retrieve disks for
     .PARAMETER fromTime
@@ -22432,7 +22437,7 @@ function Global:Get-OciDatasourcesByStorage {
 #>
 function Global:Get-OciDisksByStorage {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -22476,7 +22481,7 @@ function Global:Get-OciDisksByStorage {
                    Position=12,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -22495,12 +22500,12 @@ function Global:Get-OciDisksByStorage {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/disks"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/disks"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -22516,17 +22521,17 @@ function Global:Get-OciDisksByStorage {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -22538,7 +22543,7 @@ function Global:Get-OciDisksByStorage {
     .SYNOPSIS
     Retrieve internal volumes for one storage
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of storage to retrieve internal volumes for
     .PARAMETER fromTime
@@ -22576,7 +22581,7 @@ function Global:Get-OciDisksByStorage {
 #>
 function Global:Get-OciInternalVolumesByStorage {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -22635,7 +22640,7 @@ function Global:Get-OciInternalVolumesByStorage {
                    Position=21,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -22654,12 +22659,12 @@ function Global:Get-OciInternalVolumesByStorage {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/internalVolumes"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/internalVolumes"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -22675,19 +22680,19 @@ function Global:Get-OciInternalVolumesByStorage {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-      
+
             Write-Output $Result
         }
     }
@@ -22697,7 +22702,7 @@ function Global:Get-OciInternalVolumesByStorage {
     .SYNOPSIS
     Retrieve one storage performance
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of storage to retrieve
     .PARAMETER fromTime
@@ -22711,7 +22716,7 @@ function Global:Get-OciInternalVolumesByStorage {
 #>
 function Global:Get-OciStoragePerformance {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -22734,7 +22739,7 @@ function Global:Get-OciStoragePerformance {
                    Position=5,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -22753,12 +22758,12 @@ function Global:Get-OciStoragePerformance {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/performance"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/performance"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -22774,20 +22779,20 @@ function Global:Get-OciStoragePerformance {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Performance = ParsePerformance($Result,$Server.Timezone)
+            $Performance = ParsePerformance -Performance $Result -Timezone $Server.Timezone
             Write-Output $Performance
         }
     }
@@ -22797,7 +22802,7 @@ function Global:Get-OciStoragePerformance {
     .SYNOPSIS
     Retrieve storage ports for one storage
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of storage to retrieve storage ports for
     .PARAMETER fromTime
@@ -22825,7 +22830,7 @@ function Global:Get-OciStoragePerformance {
 #>
 function Global:Get-OciPortsByStorage {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -22869,7 +22874,7 @@ function Global:Get-OciPortsByStorage {
                    Position=12,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -22888,12 +22893,12 @@ function Global:Get-OciPortsByStorage {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/ports"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/ports"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -22909,17 +22914,17 @@ function Global:Get-OciPortsByStorage {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -22931,13 +22936,13 @@ function Global:Get-OciPortsByStorage {
     .SYNOPSIS
     Retrieve protocols of a storage.
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of storage to retrieve protocols for.
 #>
 function Global:Get-OciProtocolsByStorage {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -22948,7 +22953,7 @@ function Global:Get-OciProtocolsByStorage {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -22967,12 +22972,12 @@ function Global:Get-OciProtocolsByStorage {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/protocols"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/protocols"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -22988,17 +22993,17 @@ function Global:Get-OciProtocolsByStorage {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -23010,7 +23015,7 @@ function Global:Get-OciProtocolsByStorage {
     .SYNOPSIS
     Retrieve storage qtrees for one storage
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of storage to retrieve storage qtrees for
     .PARAMETER fromTime
@@ -23034,7 +23039,7 @@ function Global:Get-OciProtocolsByStorage {
 #>
 function Global:Get-OciQtreesByStorage {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -23072,7 +23077,7 @@ function Global:Get-OciQtreesByStorage {
                    Position=10,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -23091,12 +23096,12 @@ function Global:Get-OciQtreesByStorage {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/qtrees"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/qtrees"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -23112,17 +23117,17 @@ function Global:Get-OciQtreesByStorage {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -23134,7 +23139,7 @@ function Global:Get-OciQtreesByStorage {
     .SYNOPSIS
     Retrieve storage shares for one storage
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of storage to retrieve storage shares for
     .PARAMETER fromTime
@@ -23154,7 +23159,7 @@ function Global:Get-OciQtreesByStorage {
 #>
 function Global:Get-OciSharesByStorage {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -23186,7 +23191,7 @@ function Global:Get-OciSharesByStorage {
                    Position=8,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -23205,12 +23210,12 @@ function Global:Get-OciSharesByStorage {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/shares"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/shares"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -23226,19 +23231,19 @@ function Global:Get-OciSharesByStorage {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -23248,7 +23253,7 @@ function Global:Get-OciSharesByStorage {
     .SYNOPSIS
     Retrieve storage nodes for one storage
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of storage to retrieve storage nodes for
     .PARAMETER fromTime
@@ -23276,7 +23281,7 @@ function Global:Get-OciSharesByStorage {
 #>
 function Global:Get-OciStorageNodesByStorage {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -23320,7 +23325,7 @@ function Global:Get-OciStorageNodesByStorage {
                    Position=12,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -23339,12 +23344,12 @@ function Global:Get-OciStorageNodesByStorage {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/storageNodes"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/storageNodes"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -23360,19 +23365,19 @@ function Global:Get-OciStorageNodesByStorage {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -23382,7 +23387,7 @@ function Global:Get-OciStorageNodesByStorage {
     .SYNOPSIS
     Retrieve storage pools for one storage
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of storage to retrieve storage pools for
     .PARAMETER fromTime
@@ -23414,7 +23419,7 @@ function Global:Get-OciStorageNodesByStorage {
 #>
 function Global:Get-OciStoragePoolsByStorage {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -23464,7 +23469,7 @@ function Global:Get-OciStoragePoolsByStorage {
                    Position=14,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -23483,12 +23488,12 @@ function Global:Get-OciStoragePoolsByStorage {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/storagePools"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/storagePools"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -23504,17 +23509,17 @@ function Global:Get-OciStoragePoolsByStorage {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -23526,7 +23531,7 @@ function Global:Get-OciStoragePoolsByStorage {
     .SYNOPSIS
     Retrieve storage resources for one storage
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of storage to retrieve storage resources for
     .PARAMETER fromTime
@@ -23552,7 +23557,7 @@ function Global:Get-OciStoragePoolsByStorage {
 #>
 function Global:Get-OciStorageResourcesByStorage {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -23593,7 +23598,7 @@ function Global:Get-OciStorageResourcesByStorage {
                    Position=11,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -23612,12 +23617,12 @@ function Global:Get-OciStorageResourcesByStorage {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/storageResources"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/storageResources"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -23633,17 +23638,17 @@ function Global:Get-OciStorageResourcesByStorage {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -23655,7 +23660,7 @@ function Global:Get-OciStorageResourcesByStorage {
     .SYNOPSIS
     Retrieve volumes for one storage
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of storage to retrieve volumes for
     .PARAMETER fromTime
@@ -23701,7 +23706,7 @@ function Global:Get-OciStorageResourcesByStorage {
 #>
 function Global:Get-OciVolumesByStorage {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -23772,7 +23777,7 @@ function Global:Get-OciVolumesByStorage {
                    Position=4,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -23791,12 +23796,12 @@ function Global:Get-OciVolumesByStorage {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/volumes"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/storages/$id/volumes"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -23812,19 +23817,19 @@ function Global:Get-OciVolumesByStorage {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-       
+
             Write-Output $Result
         }
     }
@@ -23864,7 +23869,7 @@ function Global:Get-OciVolumesByStorage {
 #>
 function Global:Get-OciSwitches {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                     Position=0,
@@ -23906,7 +23911,7 @@ function Global:Get-OciSwitches {
                    Position=12,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -23925,7 +23930,7 @@ function Global:Get-OciSwitches {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
@@ -23935,8 +23940,8 @@ function Global:Get-OciSwitches {
                 $Limit = 50
             }
 
-            $Uri = $Server.BaseUri + "/rest/v1/assets/switches"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/switches"
+
             $Uri += '?'
             $Separator = ''
             if ($fromTime) {
@@ -23962,20 +23967,20 @@ function Global:Get-OciSwitches {
             if ($expand) {
                 $Uri += "$($Separator)expand=$expand"
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Switches = ParseSwitches($Result,$Server.Timezone)
+            $Switches = ParseSwitches -Switches $Result -Timezone $Server.Timezone
             if ($Switches) { Write-Output $Switches }
 
             if ($FetchAll -and @($Switches).Count -eq $Limit) {
@@ -23990,38 +23995,38 @@ function Global:Get-OciSwitches {
     .SYNOPSIS
     Retrieve total count of switches.
     .DESCRIPTION
-    
+
 
 #>
 function Global:Get-OciSwitchCount {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/assets/switches/count"
- 
+
         try {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
 
         Write-Output $Result.Value
@@ -24058,7 +24063,7 @@ function Global:Get-OciSwitchCount {
 #>
 function Global:Get-OciSwitch {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -24099,7 +24104,7 @@ function Global:Get-OciSwitch {
                    Position=11,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -24118,12 +24123,12 @@ function Global:Get-OciSwitch {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/switches/$id"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/switches/$id"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -24139,20 +24144,20 @@ function Global:Get-OciSwitch {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Switch = ParseSwitches($Result,$Server.Timezone)
+            $Switch = ParseSwitches -Switches $Result -Timezone $Server.Timezone
             Write-Output $Switch
         }
     }
@@ -24175,7 +24180,7 @@ function Global:Get-OciSwitch {
 }
 ]
 </pre>
-                    
+
     .PARAMETER id
     Id of object to delete
         .PARAMETER definition
@@ -24183,7 +24188,7 @@ function Global:Get-OciSwitch {
 #>
 function Global:Remove-OciAnnotationsBySwitch {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -24197,7 +24202,7 @@ function Global:Remove-OciAnnotationsBySwitch {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -24216,12 +24221,12 @@ function Global:Remove-OciAnnotationsBySwitch {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/switches/$id/annotations"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/switches/$id/annotations"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -24237,21 +24242,21 @@ function Global:Remove-OciAnnotationsBySwitch {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -24271,7 +24276,7 @@ function Global:Remove-OciAnnotationsBySwitch {
 #>
 function Global:Get-OciAnnotationsBySwitch {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -24288,7 +24293,7 @@ function Global:Get-OciAnnotationsBySwitch {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -24307,12 +24312,12 @@ function Global:Get-OciAnnotationsBySwitch {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/switches/$id/annotations"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/switches/$id/annotations"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -24328,19 +24333,19 @@ function Global:Get-OciAnnotationsBySwitch {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -24363,7 +24368,7 @@ function Global:Get-OciAnnotationsBySwitch {
   }
 ]
 </pre>
-            
+
     .PARAMETER id
     Id of object to update
         .PARAMETER definition
@@ -24371,7 +24376,7 @@ function Global:Get-OciAnnotationsBySwitch {
 #>
 function Global:Update-OciAnnotationsBySwitch {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -24385,7 +24390,7 @@ function Global:Update-OciAnnotationsBySwitch {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -24404,12 +24409,12 @@ function Global:Update-OciAnnotationsBySwitch {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/switches/$id/annotations"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/switches/$id/annotations"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -24425,19 +24430,19 @@ function Global:Update-OciAnnotationsBySwitch {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                     Write-Verbose "Body: $Body"
                     $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PUT -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "PUT to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -24461,7 +24466,7 @@ function Global:Update-OciAnnotationsBySwitch {
     }
 ]
 </pre>
-            
+
     .PARAMETER id
     Id of object to update
         .PARAMETER computeResources
@@ -24471,7 +24476,7 @@ function Global:Update-OciAnnotationsBySwitch {
 #>
 function Global:Bulk-OciUnAssignApplicationsFromAsset {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -24488,7 +24493,7 @@ function Global:Bulk-OciUnAssignApplicationsFromAsset {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -24507,12 +24512,12 @@ function Global:Bulk-OciUnAssignApplicationsFromAsset {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/switches/$id/applications"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/switches/$id/applications"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -24528,19 +24533,19 @@ function Global:Bulk-OciUnAssignApplicationsFromAsset {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: "
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -24568,7 +24573,7 @@ function Global:Bulk-OciUnAssignApplicationsFromAsset {
 #>
 function Global:Get-OciApplicationsBySwitch {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -24594,7 +24599,7 @@ function Global:Get-OciApplicationsBySwitch {
                    Position=6,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -24613,12 +24618,12 @@ function Global:Get-OciApplicationsBySwitch {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/switches/$id/applications"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/switches/$id/applications"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -24634,19 +24639,19 @@ function Global:Get-OciApplicationsBySwitch {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-       
+
             Write-Output $Result
         }
     }
@@ -24668,7 +24673,7 @@ function Global:Get-OciApplicationsBySwitch {
     }
 ]
 </pre>
-            
+
     .PARAMETER id
     Id of object to update
         .PARAMETER computeResources
@@ -24678,7 +24683,7 @@ function Global:Get-OciApplicationsBySwitch {
 #>
 function Global:Bulk-OciAssignApplicationsToAsset {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -24695,7 +24700,7 @@ function Global:Bulk-OciAssignApplicationsToAsset {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -24714,12 +24719,12 @@ function Global:Bulk-OciAssignApplicationsToAsset {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/switches/$id/applications"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/switches/$id/applications"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -24735,19 +24740,19 @@ function Global:Bulk-OciAssignApplicationsToAsset {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PATCH -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "PATCH to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -24766,7 +24771,7 @@ function Global:Bulk-OciAssignApplicationsToAsset {
     "id":"12345"
 }
 </pre>
-            
+
     .PARAMETER id
     Id of object to update
     .PARAMETER computeResources
@@ -24776,7 +24781,7 @@ function Global:Bulk-OciAssignApplicationsToAsset {
 #>
 function Global:Update-OciByTypeAndId {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -24793,7 +24798,7 @@ function Global:Update-OciByTypeAndId {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -24812,12 +24817,12 @@ function Global:Update-OciByTypeAndId {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/switches/$id/applications"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/switches/$id/applications"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -24833,19 +24838,19 @@ function Global:Update-OciByTypeAndId {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method POST -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "POST to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -24885,7 +24890,7 @@ function Global:Update-OciByTypeAndId {
 #>
 function Global:Get-OciDatasourcesBySwitch {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -24929,7 +24934,7 @@ function Global:Get-OciDatasourcesBySwitch {
                    Position=12,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -24948,12 +24953,12 @@ function Global:Get-OciDatasourcesBySwitch {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/switches/$id/datasources"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/switches/$id/datasources"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -24969,20 +24974,20 @@ function Global:Get-OciDatasourcesBySwitch {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Datasources = ParseDatasources($Result)
+            $Datasources = ParseDatasources -Datasources $Result
             Write-Output $Datasources
         }
     }
@@ -24992,7 +24997,7 @@ function Global:Get-OciDatasourcesBySwitch {
     .SYNOPSIS
     Retrieve one fabric from switch
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of switch.
     .PARAMETER fromTime
@@ -25008,7 +25013,7 @@ function Global:Get-OciDatasourcesBySwitch {
 #>
 function Global:Get-OciFabricBySwitch {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -25034,7 +25039,7 @@ function Global:Get-OciFabricBySwitch {
                    Position=6,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -25053,12 +25058,12 @@ function Global:Get-OciFabricBySwitch {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/switches/$id/fabric"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/switches/$id/fabric"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -25074,17 +25079,17 @@ function Global:Get-OciFabricBySwitch {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -25096,7 +25101,7 @@ function Global:Get-OciFabricBySwitch {
     .SYNOPSIS
     Retrieve one switch performance.
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of switch.
     .PARAMETER fromTime
@@ -25110,7 +25115,7 @@ function Global:Get-OciFabricBySwitch {
 #>
 function Global:Get-OciSwitchPerformance {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -25133,7 +25138,7 @@ function Global:Get-OciSwitchPerformance {
                    Position=5,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -25152,12 +25157,12 @@ function Global:Get-OciSwitchPerformance {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/switches/$id/performance"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/switches/$id/performance"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -25173,20 +25178,20 @@ function Global:Get-OciSwitchPerformance {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Performance = ParsePerformance($Result,$Server.Timezone)
+            $Performance = ParsePerformance -Performance $Result -Timezone $Server.Timezone
             Write-Output $Performance
         }
     }
@@ -25196,7 +25201,7 @@ function Global:Get-OciSwitchPerformance {
     .SYNOPSIS
     Retrieve switch ports for one switch
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of switch to retrieve switch ports for
     .PARAMETER fromTime
@@ -25224,7 +25229,7 @@ function Global:Get-OciSwitchPerformance {
 #>
 function Global:Get-OciPortsBySwitch {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -25268,7 +25273,7 @@ function Global:Get-OciPortsBySwitch {
                    Position=12,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -25287,12 +25292,12 @@ function Global:Get-OciPortsBySwitch {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/switches/$id/ports"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/switches/$id/ports"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -25308,17 +25313,17 @@ function Global:Get-OciPortsBySwitch {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -25370,7 +25375,7 @@ function Global:Get-OciPortsBySwitch {
 #>
 function Global:Get-OciVirtualMachines {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                     Position=0,
@@ -25427,7 +25432,7 @@ function Global:Get-OciVirtualMachines {
                    Position=17,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -25446,7 +25451,7 @@ function Global:Get-OciVirtualMachines {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
@@ -25456,8 +25461,8 @@ function Global:Get-OciVirtualMachines {
                 $Limit = 50
             }
 
-            $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines"
+
             $Uri += '?'
             $Separator = ''
             if ($fromTime) {
@@ -25483,20 +25488,20 @@ function Global:Get-OciVirtualMachines {
             if ($expand) {
                 $Uri += "$($Separator)expand=$expand"
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $VirtualMachines = ParseVirtualMachines($Result,$Server.Timezone)
+            $VirtualMachines = ParseVirtualMachines -VirtualMachines $Result -Timezone $Server.Timezone
             Write-Output $VirtualMachines
 
             if ($FetchAll -and @($VirtualMachines).Count -eq $Limit) {
@@ -25515,35 +25520,35 @@ function Global:Get-OciVirtualMachines {
 #>
 function Global:Get-OciVirtualMachineCount {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                    Position=0,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/count"
- 
+
         try {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-           
+
         Write-Output $Result.Value
     }
 }
@@ -25586,7 +25591,7 @@ function Global:Get-OciVirtualMachineCount {
 #>
 function Global:Get-OciVirtualMachine {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -25639,7 +25644,7 @@ function Global:Get-OciVirtualMachine {
                    Position=15,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -25658,12 +25663,12 @@ function Global:Get-OciVirtualMachine {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -25679,20 +25684,20 @@ function Global:Get-OciVirtualMachine {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $VirtualMachine = ParseVirtualMachines($Result,$Server.Timezone)
+            $VirtualMachine = ParseVirtualMachines -VirtualMachines $Result -Timezone $Server.Timezone
             Write-Output $VirtualMachine
         }
     }
@@ -25702,7 +25707,7 @@ function Global:Get-OciVirtualMachine {
     .SYNOPSIS
     Remove annotations from virtual machine
     .DESCRIPTION
-    Remove annotations from virtual machine               
+    Remove annotations from virtual machine
     .PARAMETER id
     Id of object to delete
     .PARAMETER Annotations
@@ -25712,7 +25717,7 @@ function Global:Get-OciVirtualMachine {
 #>
 function Global:Remove-OciAnnotationsByVirtualMachine {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -25729,35 +25734,35 @@ function Global:Remove-OciAnnotationsByVirtualMachine {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
-        $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id/annotations"    
-        
+        $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id/annotations"
+
         if ($Definition) {
             $Uri += "?expand=definition"
-        }    
-        
+        }
+
         if (!$Annotations) {
             $Annotations = Get-OciAnnotationsByVirtualMachine -id $id -definition -Server $Server
         }
 
         try {
-            $Body = ConvertTo-Json @($Annotations | ? { $_.definition } | % { @{definition=@{id=$_.definition.id}} } ) -Compress
+            $Body = ConvertTo-Json @($Annotations | Where-Object { $_.definition } | ForEach-Object { @{definition=@{id=$_.definition.id}} } ) -Compress
             Write-Verbose "Body: $Body"
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
-       
+
         Write-Output $Result
     }
 }
@@ -25776,7 +25781,7 @@ function Global:Remove-OciAnnotationsByVirtualMachine {
 #>
 function Global:Get-OciAnnotationsByVirtualMachine {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -25793,31 +25798,31 @@ function Global:Get-OciAnnotationsByVirtualMachine {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
-        $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id/annotations"     
-            
+        $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id/annotations"
+
         if ($Definition) {
             $Uri += "?expand=definition"
-        }         
- 
+        }
+
         try {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
 
         Write-Output $Result
@@ -25828,7 +25833,7 @@ function Global:Get-OciAnnotationsByVirtualMachine {
     .SYNOPSIS
     Update Annotations of Virtual Machine
     .DESCRIPTION
-    Update Annotations of Virtual Machine  
+    Update Annotations of Virtual Machine
     .PARAMETER id
     Id of object to update
     .PARAMETER Annotations
@@ -25838,7 +25843,7 @@ function Global:Get-OciAnnotationsByVirtualMachine {
 #>
 function Global:Update-OciAnnotationsByVirtualMachine {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -25855,35 +25860,35 @@ function Global:Update-OciAnnotationsByVirtualMachine {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
-        $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id/annotations"            
+        $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id/annotations"
 
         if ($Definition) {
             $Uri += "?expand=definition"
-        } 
- 
+        }
+
         try {
-            $Body = ConvertTo-Json $($Annotations | % { @{rawValue=$_.rawValue;definition=@{id=$_.definition.id}} } ) -Compress
+            $Body = ConvertTo-Json $($Annotations | ForEach-Object { @{rawValue=$_.rawValue;definition=@{id=$_.definition.id}} } ) -Compress
             Write-Verbose "Body: $Body"
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PUT -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "PUT to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
-           
+
         Write-Output $Result
     }
 }
@@ -25904,7 +25909,7 @@ function Global:Update-OciAnnotationsByVirtualMachine {
     }
 ]
 </pre>
-            
+
     .PARAMETER id
     Id of object to update
         .PARAMETER computeResources
@@ -25914,7 +25919,7 @@ function Global:Update-OciAnnotationsByVirtualMachine {
 #>
 function Global:Bulk-OciUnAssignApplicationsFromAsset {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -25931,7 +25936,7 @@ function Global:Bulk-OciUnAssignApplicationsFromAsset {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -25950,12 +25955,12 @@ function Global:Bulk-OciUnAssignApplicationsFromAsset {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id/applications"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id/applications"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -25971,19 +25976,19 @@ function Global:Bulk-OciUnAssignApplicationsFromAsset {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -26011,7 +26016,7 @@ function Global:Bulk-OciUnAssignApplicationsFromAsset {
 #>
 function Global:Get-OciApplicationsByVirtualMachine {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -26037,7 +26042,7 @@ function Global:Get-OciApplicationsByVirtualMachine {
                    Position=6,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -26056,12 +26061,12 @@ function Global:Get-OciApplicationsByVirtualMachine {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id/applications"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id/applications"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -26077,17 +26082,17 @@ function Global:Get-OciApplicationsByVirtualMachine {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -26111,7 +26116,7 @@ function Global:Get-OciApplicationsByVirtualMachine {
     }
 ]
 </pre>
-            
+
     .PARAMETER id
     Id of object to update
         .PARAMETER computeResources
@@ -26121,7 +26126,7 @@ function Global:Get-OciApplicationsByVirtualMachine {
 #>
 function Global:Bulk-OciAssignApplicationsToAsset {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -26138,7 +26143,7 @@ function Global:Bulk-OciAssignApplicationsToAsset {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -26157,12 +26162,12 @@ function Global:Bulk-OciAssignApplicationsToAsset {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id/applications"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id/applications"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -26178,19 +26183,19 @@ function Global:Bulk-OciAssignApplicationsToAsset {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PATCH -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "PATCH to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -26209,7 +26214,7 @@ function Global:Bulk-OciAssignApplicationsToAsset {
     "id":"12345"
 }
 </pre>
-            
+
     .PARAMETER id
     Id of object to update
         .PARAMETER computeResources
@@ -26219,7 +26224,7 @@ function Global:Bulk-OciAssignApplicationsToAsset {
 #>
 function Global:Update-OciByTypeAndId {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -26236,7 +26241,7 @@ function Global:Update-OciByTypeAndId {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -26255,12 +26260,12 @@ function Global:Update-OciByTypeAndId {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id/applications"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id/applications"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -26276,19 +26281,19 @@ function Global:Update-OciByTypeAndId {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method POST -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "POST to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -26312,7 +26317,7 @@ function Global:Update-OciByTypeAndId {
 #>
 function Global:Remove-OciByTypeAndId {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -26332,7 +26337,7 @@ function Global:Remove-OciByTypeAndId {
                    Position=4,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -26351,12 +26356,12 @@ function Global:Remove-OciByTypeAndId {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id/applications/$appId"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id/applications/$appId"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -26372,17 +26377,17 @@ function Global:Remove-OciByTypeAndId {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -26420,7 +26425,7 @@ function Global:Remove-OciByTypeAndId {
 #>
 function Global:Get-OciDataStoreByVirtualMachine {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -26461,7 +26466,7 @@ function Global:Get-OciDataStoreByVirtualMachine {
                    Position=11,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -26480,12 +26485,12 @@ function Global:Get-OciDataStoreByVirtualMachine {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id/dataStore"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id/dataStore"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -26501,20 +26506,20 @@ function Global:Get-OciDataStoreByVirtualMachine {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
-            $Datastore = ParseDatastores $Result $Timezone
+
+            $Datastore = ParseDatastores -Datastores $Result -Timezone $Timezone
             Write-Output $Datastore
         }
     }
@@ -26552,7 +26557,7 @@ function Global:Get-OciDataStoreByVirtualMachine {
 #>
 function Global:Get-OciDatasourcesByVirtualMachine {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -26596,7 +26601,7 @@ function Global:Get-OciDatasourcesByVirtualMachine {
                    Position=11,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -26615,12 +26620,12 @@ function Global:Get-OciDatasourcesByVirtualMachine {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id/datasources"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id/datasources"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -26636,20 +26641,20 @@ function Global:Get-OciDatasourcesByVirtualMachine {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Datasources = ParseDatasources($Result)
+            $Datasources = ParseDatasources -Datasources $Result
             Write-Output $Datasources
         }
     }
@@ -26677,7 +26682,7 @@ function Global:Get-OciDatasourcesByVirtualMachine {
 #>
 function Global:Get-OciFileSystemsByVirtualMachine {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -26706,7 +26711,7 @@ function Global:Get-OciFileSystemsByVirtualMachine {
                    Position=7,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -26725,12 +26730,12 @@ function Global:Get-OciFileSystemsByVirtualMachine {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id/fileSystems"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id/fileSystems"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -26746,17 +26751,17 @@ function Global:Get-OciFileSystemsByVirtualMachine {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -26802,7 +26807,7 @@ function Global:Get-OciFileSystemsByVirtualMachine {
 #>
 function Global:Get-OciHostByVirtualMachine {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -26855,7 +26860,7 @@ function Global:Get-OciHostByVirtualMachine {
                    Position=15,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -26874,12 +26879,12 @@ function Global:Get-OciHostByVirtualMachine {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id/host"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id/host"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -26895,20 +26900,20 @@ function Global:Get-OciHostByVirtualMachine {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Hosts = ParseHosts($Result,$Server.Timezone)
+            $Hosts = ParseHosts -Hosts $Result -Timezone $Server.Timezone
             Write-Output $Hosts
         }
     }
@@ -26932,7 +26937,7 @@ function Global:Get-OciHostByVirtualMachine {
 #>
 function Global:Get-OciVirtualMachinePerformance {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -26955,7 +26960,7 @@ function Global:Get-OciVirtualMachinePerformance {
                    Position=5,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -26974,12 +26979,12 @@ function Global:Get-OciVirtualMachinePerformance {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id/performance"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id/performance"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -26995,20 +27000,20 @@ function Global:Get-OciVirtualMachinePerformance {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Performance = ParsePerformance($Result,$Server.Timezone)
+            $Performance = ParsePerformance -Performance $Result -Timezone $Server.Timezone
             Write-Output $Performance
         }
     }
@@ -27046,7 +27051,7 @@ function Global:Get-OciVirtualMachinePerformance {
 #>
 function Global:Get-OciPortsByVirtualMachine {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -27090,7 +27095,7 @@ function Global:Get-OciPortsByVirtualMachine {
                    Position=12,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -27109,12 +27114,12 @@ function Global:Get-OciPortsByVirtualMachine {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id/ports"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id/ports"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -27130,20 +27135,20 @@ function Global:Get-OciPortsByVirtualMachine {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Ports = ParsePorts($Result,$Server.Timezone)
+            $Ports = ParsePorts -Ports $Result -Timezone $Server.Timezone
             Write-Output $Ports
         }
     }
@@ -27179,7 +27184,7 @@ function Global:Get-OciPortsByVirtualMachine {
 #>
 function Global:Get-OciStorageResourcesByVirtualMachine {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -27220,7 +27225,7 @@ function Global:Get-OciStorageResourcesByVirtualMachine {
                    Position=11,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -27239,12 +27244,12 @@ function Global:Get-OciStorageResourcesByVirtualMachine {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id/storageResources"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id/storageResources"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -27260,20 +27265,20 @@ function Global:Get-OciStorageResourcesByVirtualMachine {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $StorageResources = ParseStorageResources($Result)
+            $StorageResources = ParseStorageResources -StorageResources $Result
             Write-Output $StorageResources
         }
     }
@@ -27309,7 +27314,7 @@ function Global:Get-OciStorageResourcesByVirtualMachine {
 #>
 function Global:Get-OciVmdksByVirtualMachine {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -27350,7 +27355,7 @@ function Global:Get-OciVmdksByVirtualMachine {
                    Position=11,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -27369,12 +27374,12 @@ function Global:Get-OciVmdksByVirtualMachine {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id/vmdks"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/virtualMachines/$id/vmdks"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -27390,20 +27395,20 @@ function Global:Get-OciVmdksByVirtualMachine {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
-            $Vmdks = ParseVmdks($Result,$Server.Timezone)
+
+            $Vmdks = ParseVmdks -Vmdks $Result -Timezone $Server.Timezone
             Write-Output $Vmdks
         }
     }
@@ -27441,7 +27446,7 @@ function Global:Get-OciVmdksByVirtualMachine {
 #>
 function Global:Get-OciVmdk {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -27482,7 +27487,7 @@ function Global:Get-OciVmdk {
                    Position=11,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -27501,12 +27506,12 @@ function Global:Get-OciVmdk {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/vmdks/$id"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/vmdks/$id"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -27522,20 +27527,20 @@ function Global:Get-OciVmdk {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
-            $Vmdk = ParseVmdks($Result,$Server.Timezone)
+
+            $Vmdk = ParseVmdks -Vmdks $Result -Timezone $Server.Timezone
             Write-Output $Vmdk
         }
     }
@@ -27558,7 +27563,7 @@ function Global:Get-OciVmdk {
 }
 ]
 </pre>
-                    
+
     .PARAMETER id
     Id of object to delete
         .PARAMETER definition
@@ -27566,7 +27571,7 @@ function Global:Get-OciVmdk {
 #>
 function Global:Remove-OciAnnotationsByVmdk {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -27580,7 +27585,7 @@ function Global:Remove-OciAnnotationsByVmdk {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -27599,12 +27604,12 @@ function Global:Remove-OciAnnotationsByVmdk {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/vmdks/$id/annotations"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/vmdks/$id/annotations"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -27620,19 +27625,19 @@ function Global:Remove-OciAnnotationsByVmdk {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -27654,7 +27659,7 @@ function Global:Remove-OciAnnotationsByVmdk {
 #>
 function Global:Get-OciAnnotationsByVmdk {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -27671,7 +27676,7 @@ function Global:Get-OciAnnotationsByVmdk {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -27690,12 +27695,12 @@ function Global:Get-OciAnnotationsByVmdk {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/vmdks/$id/annotations"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/vmdks/$id/annotations"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -27711,19 +27716,19 @@ function Global:Get-OciAnnotationsByVmdk {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -27746,7 +27751,7 @@ function Global:Get-OciAnnotationsByVmdk {
   }
 ]
 </pre>
-            
+
     .PARAMETER id
     Id of object to update
         .PARAMETER definition
@@ -27754,7 +27759,7 @@ function Global:Get-OciAnnotationsByVmdk {
 #>
 function Global:Update-OciAnnotationsByVmdk {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -27768,7 +27773,7 @@ function Global:Update-OciAnnotationsByVmdk {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -27787,12 +27792,12 @@ function Global:Update-OciAnnotationsByVmdk {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/vmdks/$id/annotations"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/vmdks/$id/annotations"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -27808,19 +27813,19 @@ function Global:Update-OciAnnotationsByVmdk {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: "
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PUT -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "PUT to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -27860,7 +27865,7 @@ function Global:Update-OciAnnotationsByVmdk {
 #>
 function Global:Get-OciDatasourcesByVmdk {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -27904,7 +27909,7 @@ function Global:Get-OciDatasourcesByVmdk {
                    Position=12,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -27923,12 +27928,12 @@ function Global:Get-OciDatasourcesByVmdk {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/vmdks/$id/datasources"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/vmdks/$id/datasources"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -27944,20 +27949,20 @@ function Global:Get-OciDatasourcesByVmdk {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
-            $Datasources = ParseDatasources($Result)
+
+            $Datasources = ParseDatasources -Datasources $Result
             Write-Output $Datasources
         }
     }
@@ -27981,7 +27986,7 @@ function Global:Get-OciDatasourcesByVmdk {
 #>
 function Global:Get-OciVmdkPerformance {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -28004,7 +28009,7 @@ function Global:Get-OciVmdkPerformance {
                    Position=5,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -28023,12 +28028,12 @@ function Global:Get-OciVmdkPerformance {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/vmdks/$id/performance"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/vmdks/$id/performance"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -28044,20 +28049,20 @@ function Global:Get-OciVmdkPerformance {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Performance = ParsePerformance($Result,$Server.Timezone)
+            $Performance = ParsePerformance -Performance $Result -Timezone $Server.Timezone
             Write-Output $Performance
         }
     }
@@ -28093,7 +28098,7 @@ function Global:Get-OciVmdkPerformance {
 #>
 function Global:Get-OciStorageResourcesByVmdk {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -28134,7 +28139,7 @@ function Global:Get-OciStorageResourcesByVmdk {
                    Position=11,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -28153,12 +28158,12 @@ function Global:Get-OciStorageResourcesByVmdk {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/vmdks/$id/storageResources"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/vmdks/$id/storageResources"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -28174,20 +28179,20 @@ function Global:Get-OciStorageResourcesByVmdk {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $StorageResources = ParseStorageResources($Result)
+            $StorageResources = ParseStorageResources -StorageResources $Result
             Write-Output $StorageResources
         }
     }
@@ -28231,7 +28236,7 @@ function Global:Get-OciStorageResourcesByVmdk {
 #>
 function Global:Get-OciVirtualMachineByVmdk {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -28284,7 +28289,7 @@ function Global:Get-OciVirtualMachineByVmdk {
                    Position=15,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -28303,12 +28308,12 @@ function Global:Get-OciVirtualMachineByVmdk {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/vmdks/$id/virtualMachine"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/vmdks/$id/virtualMachine"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -28324,20 +28329,20 @@ function Global:Get-OciVirtualMachineByVmdk {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $VirtualMachine = ParseVirtualMachines($Result,$Server.Timezone)
+            $VirtualMachine = ParseVirtualMachines -VirtualMachines $Result -Timezone $Server.Timezone
             Write-Output $VirtualMachine
         }
     }
@@ -28395,7 +28400,7 @@ function Global:Get-OciVirtualMachineByVmdk {
 #>
 function Global:Get-OciVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -28466,7 +28471,7 @@ function Global:Get-OciVolume {
                    Position=9,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -28485,12 +28490,12 @@ function Global:Get-OciVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -28506,20 +28511,20 @@ function Global:Get-OciVolume {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Volume = ParseVolumes($Result)
+            $Volume = ParseVolumes -Volumes $Result
             Write-Output $Volume
         }
     }
@@ -28542,7 +28547,7 @@ function Global:Get-OciVolume {
 }
 ]
 </pre>
-                    
+
     .PARAMETER id
     Id of object to delete
         .PARAMETER definition
@@ -28550,7 +28555,7 @@ function Global:Get-OciVolume {
 #>
 function Global:Remove-OciAnnotationsByVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -28564,7 +28569,7 @@ function Global:Remove-OciAnnotationsByVolume {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -28583,12 +28588,12 @@ function Global:Remove-OciAnnotationsByVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/annotations"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/annotations"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -28604,19 +28609,19 @@ function Global:Remove-OciAnnotationsByVolume {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -28638,7 +28643,7 @@ function Global:Remove-OciAnnotationsByVolume {
 #>
 function Global:Get-OciAnnotationsByVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -28655,7 +28660,7 @@ function Global:Get-OciAnnotationsByVolume {
                    Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -28674,12 +28679,12 @@ function Global:Get-OciAnnotationsByVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/annotations"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/annotations"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -28695,17 +28700,17 @@ function Global:Get-OciAnnotationsByVolume {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -28730,7 +28735,7 @@ function Global:Get-OciAnnotationsByVolume {
   }
 ]
 </pre>
-            
+
     .PARAMETER id
     Id of object to update
         .PARAMETER definition
@@ -28738,7 +28743,7 @@ function Global:Get-OciAnnotationsByVolume {
 #>
 function Global:Update-OciAnnotationsByVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -28752,7 +28757,7 @@ function Global:Update-OciAnnotationsByVolume {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -28771,12 +28776,12 @@ function Global:Update-OciAnnotationsByVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/annotations"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/annotations"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -28792,19 +28797,19 @@ function Global:Update-OciAnnotationsByVolume {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Body = ""
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PUT -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "PUT to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -28816,7 +28821,7 @@ function Global:Update-OciAnnotationsByVolume {
     .SYNOPSIS
     Bulk un-assign applications from volume
     .DESCRIPTION
-    Bulk un-assign applications from volume   
+    Bulk un-assign applications from volume
     .PARAMETER id
     Id of volume to remove applications from
     .PARAMETER computeResources
@@ -28826,7 +28831,7 @@ function Global:Update-OciAnnotationsByVolume {
 #>
 function Global:Remove-OciApplicationsFromVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -28846,7 +28851,7 @@ function Global:Remove-OciApplicationsFromVolume {
                    Position=4,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -28865,26 +28870,26 @@ function Global:Remove-OciApplicationsFromVolume {
             }
         }
     }
-   
+
     Process {
-        $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/applications"            
- 
+        $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/applications"
+
         if (!$applicationId) {
-            $applicationId = Get-OciApplicationsByVolume -id $id | select -ExpandProperty id
+            $applicationId = Get-OciApplicationsByVolume -id $id | Select-Object -ExpandProperty id
         }
 
         try {
-            $Body = ConvertTo-Json @($applicationId | % { @{id=$_} }) -Compress
+            $Body = ConvertTo-Json @($applicationId | ForEach-Object { @{id=$_} }) -Compress
             Write-Verbose "Body: $Body"
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
 
         Write-Output $Result
@@ -28911,7 +28916,7 @@ function Global:Remove-OciApplicationsFromVolume {
 #>
 function Global:Get-OciApplicationsByVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -28937,7 +28942,7 @@ function Global:Get-OciApplicationsByVolume {
                    Position=6,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -28956,12 +28961,12 @@ function Global:Get-OciApplicationsByVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/applications"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/applications"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -28977,19 +28982,19 @@ function Global:Get-OciApplicationsByVolume {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -29011,7 +29016,7 @@ function Global:Get-OciApplicationsByVolume {
     }
 ]
 </pre>
-            
+
     .PARAMETER id
     Id of object to update
         .PARAMETER computeResources
@@ -29021,7 +29026,7 @@ function Global:Get-OciApplicationsByVolume {
 #>
 function Global:Add-OciApplicationsToVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -29043,7 +29048,7 @@ function Global:Add-OciApplicationsToVolume {
                    Position=4,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -29062,12 +29067,12 @@ function Global:Add-OciApplicationsToVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/applications"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/applications"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -29083,21 +29088,21 @@ function Global:Add-OciApplicationsToVolume {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
-                $Body = ConvertTo-Json @($applicationId | % { @{id=$_} }) -Compress
+                $Body = ConvertTo-Json @($applicationId | ForEach-Object { @{id=$_} }) -Compress
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PATCH -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "PATCH to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -29114,7 +29119,7 @@ function Global:Add-OciApplicationsToVolume {
     "id":"12345"
 }
 </pre>
-            
+
     .PARAMETER id
     Id of object to update
     .PARAMETER applicationId
@@ -29126,7 +29131,7 @@ function Global:Add-OciApplicationsToVolume {
 #>
 function Global:Update-OciApplicationsByVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -29146,7 +29151,7 @@ function Global:Update-OciApplicationsByVolume {
                    Position=4,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -29165,12 +29170,12 @@ function Global:Update-OciApplicationsByVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/applications"                      
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/applications"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -29186,21 +29191,21 @@ function Global:Update-OciApplicationsByVolume {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
-            try {                
-                $Body = ConvertTo-Json ($applicationId | % { @{id=$_} }) -Compress
+
+            try {
+                $Body = ConvertTo-Json ($applicationId | ForEach-Object { @{id=$_} }) -Compress
                 Write-Verbose "Body: $Body"
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method POST -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "POST to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-       
+
             Write-Output $Result
         }
     }
@@ -29222,7 +29227,7 @@ function Global:Update-OciApplicationsByVolume {
 #>
 function Global:Remove-OciByTypeAndId {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -29242,7 +29247,7 @@ function Global:Remove-OciByTypeAndId {
                    Position=4,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -29261,12 +29266,12 @@ function Global:Remove-OciByTypeAndId {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/applications/$appId"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/applications/$appId"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -29282,17 +29287,17 @@ function Global:Remove-OciByTypeAndId {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -29310,7 +29315,7 @@ function Global:Remove-OciByTypeAndId {
 #>
 function Global:Get-OciAutoTierPolicyByVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -29321,7 +29326,7 @@ function Global:Get-OciAutoTierPolicyByVolume {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -29340,12 +29345,12 @@ function Global:Get-OciAutoTierPolicyByVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/autoTierPolicy"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/autoTierPolicy"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -29361,19 +29366,19 @@ function Global:Get-OciAutoTierPolicyByVolume {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -29405,7 +29410,7 @@ function Global:Get-OciAutoTierPolicyByVolume {
 #>
 function Global:Get-OciComputeResourcesByVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -29440,7 +29445,7 @@ function Global:Get-OciComputeResourcesByVolume {
                    Position=9,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -29459,12 +29464,12 @@ function Global:Get-OciComputeResourcesByVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/computeResources"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/computeResources"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -29480,17 +29485,17 @@ function Global:Get-OciComputeResourcesByVolume {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -29528,7 +29533,7 @@ function Global:Get-OciComputeResourcesByVolume {
 #>
 function Global:Get-OciDatastoresByVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -29569,7 +29574,7 @@ function Global:Get-OciDatastoresByVolume {
                    Position=11,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -29588,12 +29593,12 @@ function Global:Get-OciDatastoresByVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/dataStores"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/dataStores"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -29609,19 +29614,19 @@ function Global:Get-OciDatastoresByVolume {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-           
+
             Write-Output $Result
         }
     }
@@ -29659,7 +29664,7 @@ function Global:Get-OciDatastoresByVolume {
 #>
 function Global:Get-OciDatasourcesByVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -29703,7 +29708,7 @@ function Global:Get-OciDatasourcesByVolume {
                    Position=12,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -29722,12 +29727,12 @@ function Global:Get-OciDatasourcesByVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/datasources"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/datasources"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -29743,17 +29748,17 @@ function Global:Get-OciDatasourcesByVolume {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -29803,7 +29808,7 @@ function Global:Get-OciDatasourcesByVolume {
 #>
 function Global:Get-OciInternalVolumeByVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -29862,7 +29867,7 @@ function Global:Get-OciInternalVolumeByVolume {
                    Position=17,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -29881,12 +29886,12 @@ function Global:Get-OciInternalVolumeByVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/internalVolume"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/internalVolume"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -29902,17 +29907,17 @@ function Global:Get-OciInternalVolumeByVolume {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -29924,7 +29929,7 @@ function Global:Get-OciInternalVolumeByVolume {
     .SYNOPSIS
     Retrieve one volume performance
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of volume to retrieve
     .PARAMETER fromTime
@@ -29938,7 +29943,7 @@ function Global:Get-OciInternalVolumeByVolume {
 #>
 function Global:Get-OciVolumePerformance {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -29961,7 +29966,7 @@ function Global:Get-OciVolumePerformance {
                    Position=5,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -29980,12 +29985,12 @@ function Global:Get-OciVolumePerformance {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/performance"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/performance"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -30001,20 +30006,20 @@ function Global:Get-OciVolumePerformance {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
-            $Performance = ParsePerformance($Result,$Server.Timezone)
+            $Performance = ParsePerformance -Performance $Result -Timezone $Server.Timezone
             Write-Output $Performance
         }
     }
@@ -30024,7 +30029,7 @@ function Global:Get-OciVolumePerformance {
     .SYNOPSIS
     Retrieve all storage ports and their connected ports by volume.
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of volume to retrieve the ports that are connected to storage ports.
     .PARAMETER fromTime
@@ -30052,7 +30057,7 @@ function Global:Get-OciVolumePerformance {
 #>
 function Global:Get-OciPortsByVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -30096,7 +30101,7 @@ function Global:Get-OciPortsByVolume {
                    Position=12,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -30115,12 +30120,12 @@ function Global:Get-OciPortsByVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/ports"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/ports"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -30136,17 +30141,17 @@ function Global:Get-OciPortsByVolume {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -30158,7 +30163,7 @@ function Global:Get-OciPortsByVolume {
     .SYNOPSIS
     Retrieve qtree for a given volume.
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of volume to retrieve the qtree.
     .PARAMETER fromTime
@@ -30182,7 +30187,7 @@ function Global:Get-OciPortsByVolume {
 #>
 function Global:Get-OciQtree {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -30220,7 +30225,7 @@ function Global:Get-OciQtree {
                    Position=10,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -30239,12 +30244,12 @@ function Global:Get-OciQtree {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/qtree"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/qtree"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -30260,19 +30265,19 @@ function Global:Get-OciQtree {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-       
+
             Write-Output $Result
         }
     }
@@ -30282,7 +30287,7 @@ function Global:Get-OciQtree {
     .SYNOPSIS
     Retrieve all source volumes for a given target volume.
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of target volume to retrieve the source volumes.
     .PARAMETER fromTime
@@ -30328,7 +30333,7 @@ function Global:Get-OciQtree {
 #>
 function Global:Get-OciSourceVolumesByVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -30399,7 +30404,7 @@ function Global:Get-OciSourceVolumesByVolume {
                    Position=21,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -30418,12 +30423,12 @@ function Global:Get-OciSourceVolumesByVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/replicaSources"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/replicaSources"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -30439,17 +30444,17 @@ function Global:Get-OciSourceVolumesByVolume {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -30461,7 +30466,7 @@ function Global:Get-OciSourceVolumesByVolume {
     .SYNOPSIS
     Retrieve the storage of a volume.
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of the volume to retrieve the storage.
     .PARAMETER fromTime
@@ -30503,7 +30508,7 @@ function Global:Get-OciSourceVolumesByVolume {
 #>
 function Global:Get-OciStorageByVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -30568,7 +30573,7 @@ function Global:Get-OciStorageByVolume {
                    Position=19,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -30587,12 +30592,12 @@ function Global:Get-OciStorageByVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/storage"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/storage"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -30608,17 +30613,17 @@ function Global:Get-OciStorageByVolume {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -30630,7 +30635,7 @@ function Global:Get-OciStorageByVolume {
     .SYNOPSIS
     Retrieve storage nodes for a given volume.
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of volume to retrieve the storage nodes.
     .PARAMETER fromTime
@@ -30658,7 +30663,7 @@ function Global:Get-OciStorageByVolume {
 #>
 function Global:Get-OciStorageNodesByVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -30702,7 +30707,7 @@ function Global:Get-OciStorageNodesByVolume {
                    Position=12,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -30721,12 +30726,12 @@ function Global:Get-OciStorageNodesByVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/storageNodes"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/storageNodes"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -30742,17 +30747,17 @@ function Global:Get-OciStorageNodesByVolume {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -30764,7 +30769,7 @@ function Global:Get-OciStorageNodesByVolume {
     .SYNOPSIS
     Retrieve storage pools for a given volume.
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of volume to retrieve the storage pools.
     .PARAMETER fromTime
@@ -30796,7 +30801,7 @@ function Global:Get-OciStorageNodesByVolume {
 #>
 function Global:Get-OciStoragePoolsByVolume {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -30846,7 +30851,7 @@ function Global:Get-OciStoragePoolsByVolume {
                    Position=14,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -30865,12 +30870,12 @@ function Global:Get-OciStoragePoolsByVolume {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/storagePools"
-            
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -30886,17 +30891,17 @@ function Global:Get-OciStoragePoolsByVolume {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -30908,7 +30913,7 @@ function Global:Get-OciStoragePoolsByVolume {
     .SYNOPSIS
     Retrieve virtual storage pools for a given volume.
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of volume to retrieve the virtual storage pools.
     .PARAMETER fromTime
@@ -30940,7 +30945,7 @@ function Global:Get-OciStoragePoolsByVolume {
 #>
 function Global:Get-OciVirtualStoragePools {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -30990,7 +30995,7 @@ function Global:Get-OciVirtualStoragePools {
                    Position=14,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -31009,12 +31014,12 @@ function Global:Get-OciVirtualStoragePools {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/virtualStoragePools"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/virtualStoragePools"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -31030,17 +31035,17 @@ function Global:Get-OciVirtualStoragePools {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -31052,7 +31057,7 @@ function Global:Get-OciVirtualStoragePools {
     .SYNOPSIS
     Retrieve virtualizer for a given backend volume.
     .DESCRIPTION
-    
+
     .PARAMETER id
     Id of volume to retrieve the virtualizer.
     .PARAMETER fromTime
@@ -31094,7 +31099,7 @@ function Global:Get-OciVirtualStoragePools {
 #>
 function Global:Get-OciVirtualizer {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -31159,7 +31164,7 @@ function Global:Get-OciVirtualizer {
                    Position=19,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -31178,12 +31183,12 @@ function Global:Get-OciVirtualizer {
             }
         }
     }
-   
+
     Process {
         $id = @($id)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/virtualizer"            
- 
+            $Uri = $Server.BaseUri + "/rest/v1/assets/volumes/$id/virtualizer"
+
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
                 $Separator = ''
@@ -31199,17 +31204,17 @@ function Global:Get-OciVirtualizer {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
 
             Write-Output $Result
@@ -31229,7 +31234,7 @@ function Global:Get-OciVirtualizer {
 #>
 function Global:Search-Oci {
     [CmdletBinding()]
- 
+
     PARAM (
             [parameter(Mandatory=$true,
                     Position=0,
@@ -31240,7 +31245,7 @@ function Global:Search-Oci {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         $Result = $null
         if (!$Server) {
@@ -31256,14 +31261,14 @@ function Global:Search-Oci {
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
             }
             catch {
-                $ResponseBody = ParseExceptionBody $_.Exception.Response
+                $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                 Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
             }
- 
+
             if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-                $Result = ParseJsonString($Result.Trim())
+                $Result = ParseJsonString -json $Result.Trim()
             }
-       
+
             Write-Output $Result.resultsByCategory
         }
     }
@@ -31285,7 +31290,7 @@ function Global:Get-OciHealth {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         Write-Warning "This Cmdlet uses an undocumented API call which may change in the future. Thus this Cmdlet is marked as experimental!"
         $Result = $null
@@ -31293,26 +31298,26 @@ function Global:Get-OciHealth {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/admin/health"
- 
+
         try {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
 
         foreach ($Item in $Result) {
             $Item.time = $Item.time | ConvertFrom-UnixTimestamp
         }
-       
+
         Write-Output $Result
     }
 }
@@ -31325,7 +31330,7 @@ function Global:Get-OciHealth {
 #>
 function Global:Restore-OciBackup {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                    Position=0,
@@ -31336,7 +31341,7 @@ function Global:Restore-OciBackup {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         Write-Warning "This Cmdlet uses an undocumented API call which may change in the future. Thus this Cmdlet is marked as experimental!"
         $Result = $null
@@ -31344,7 +31349,7 @@ function Global:Restore-OciBackup {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $FilePath = @($FilePath)
 
@@ -31355,7 +31360,7 @@ function Global:Restore-OciBackup {
 
             if (Test-Path $FilePath) {
                 Write-Host "Found local OCI Backup in $FilePath which will be restored"
-                
+
                 Write-Host "Starting Restore job. This can take several hours..."
 
                 $Job = Start-Job {
@@ -31365,14 +31370,14 @@ function Global:Restore-OciBackup {
 
                     Invoke-MultipartFormDataUpload -InFile $args[0] -Name "backupFile" -Uri $args[1] -Header $args[2]
                 } -ArgumentList $FilePath,$URI,$Server.Headers
-                
+
             }
             else {
                 Write-Host "No local Backup in $FilePath, trying to restore backup residing on OnCommand Insight Server"
-            
+
                 # create boundary
                 $boundary = [System.Guid]::NewGuid().ToString()
-        
+
                 # Linefeed character
                 $LF = "`r`n"
 
@@ -31400,7 +31405,7 @@ function Global:Restore-OciBackup {
             $activity = "Restore started"
             $status = "Uploading"
             Write-Progress -Activity $activity -status $status -percentComplete $percentComplete
-            sleep 2
+            Start-Sleep -Seconds 2
             $i = 0
             while ($true) {
                 $ProgressUri = $Uri + "?_=" + (get-date | ConvertTo-UnixTimestamp)
@@ -31409,12 +31414,12 @@ function Global:Restore-OciBackup {
                     $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $ProgressUri -Headers $Server.Headers -ErrorAction SilentlyContinue
                 }
                 catch {
-                    $ResponseBody = ParseExceptionBody $_.Exception.Response
+                    $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
                     Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
                 }
-                if ($i -eq 1440) { 
+                if ($i -eq 1440) {
                     Write-Host ''
-                    throw 'Backup did not finish within 24 hours' 
+                    throw 'Backup did not finish within 24 hours'
                 }
                 if ($Result.status -eq 'SUCCESSFUL') {
                     Write-Host "finished"
@@ -31425,17 +31430,17 @@ function Global:Restore-OciBackup {
                 }
                 elseif (($Result.currentStep.startTime | get-date) -ge $StartTime) {
                     $activity = $Result.currentStep.operationText
-                    $status = $Result.components.name | select -last 1
+                    $status = $Result.components.name | Select-Object -last 1
                 }
                 switch ($Result.currentStep.phaseText) {
                     "Restoring" { $percentComplete = 20 }
                     "Waiting" { $percentComplete = 30 }
-                } 
+                }
                 Write-Progress -Activity $activity -status $status -percentComplete $percentComplete
-                sleep 5
+                Start-Sleep -Seconds 5
             }
             Write-Progress -Activity $Result.currentStep.phaseText -status $Result.currentStep.operationText -percentComplete 100
-            sleep 1
+            Start-Sleep -Seconds 1
         }
         Write-Output $Result
     }
@@ -31449,7 +31454,7 @@ function Global:Restore-OciBackup {
 #>
 function Global:Get-OciBackup {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                    Position=0,
@@ -31461,7 +31466,7 @@ function Global:Get-OciBackup {
                    Position=2,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         Write-Warning "This Cmdlet uses an undocumented API call which may change in the future. Thus this Cmdlet is marked as experimental!"
         $Result = $null
@@ -31469,12 +31474,12 @@ function Global:Get-OciBackup {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $URI = $Server.BaseUri + "/rest/v1/admin/backups/current"
- 
-        Write-Host "Starting Backup"  
-        $Job = Start-Job { 
+
+        Write-Host "Starting Backup"
+        $Job = Start-Job {
             add-type @"
                     using System.Net;
                     using System.Security.Cryptography.X509Certificates;
@@ -31504,38 +31509,38 @@ function Global:Get-OciBackup {
             while ($true) {
                 $i++
                 $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
-                if ($i -eq ($Timeout * 12) -or $Job.State -ne 'Running') { 
+                if ($i -eq ($Timeout * 12) -or $Job.State -ne 'Running') {
                     Write-Progress -Activity "Backup did not complete in $Timeout minutes" -status "Backing failed" -percentComplete 100
                 }
-                if ($Result.status -eq 'SUCCESSFUL') { 
+                if ($Result.status -eq 'SUCCESSFUL') {
                     Write-Progress -Activity $Result -status $Result -percentComplete 100
-                    sleep 1
-                    break 
+                    Start-Sleep -Seconds 1
+                    break
                 }
                 Write-Progress -Activity "Backup started" -status $Result.status -percentComplete (100*$i/($Timeout*12))
-                sleep 5
+                Start-Sleep -Seconds 5
             }
             $Uri = $($Server.BaseUri) + $Result.Url
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
 
-        $FilePath = $Path + '\' + (($Uri -split '/') | select -last 1)
+        $FilePath = $Path + '\' + (($Uri -split '/') | Select-Object -last 1)
         Write-Host $FilePath
         $Date = [datetime]::ParseExact($($FilePath -replace '.+_D(.*)_[0-9]+.zip','$1'),"yyyyMMdd_HHmm",$null)
 
         try {
             Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers -OutFile $FilePath
             Write-Host "Backup Saved to $FilePath"
-            
+
             $Result = New-Object -TypeName PSCustomObject -ArgumentList @{FilePath=$FilePath;Date=$Date;URI=$Uri}
 
             Write-Output $Result
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
     }
@@ -31549,13 +31554,13 @@ function Global:Get-OciBackup {
 #>
 function Global:Get-OciBackups {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                    Position=0,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         Write-Warning "This Cmdlet uses an undocumented API call which may change in the future. Thus this Cmdlet is marked as experimental!"
         $Result = $null
@@ -31563,19 +31568,19 @@ function Global:Get-OciBackups {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/admin/backups"
- 
+
         try {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
-            
-            $Result = $Result | % { [PSCustomObject]@{FilePath=$_.path;Date=($_.date | get-date)} }
+
+            $Result = $Result | ForEach-Object { [PSCustomObject]@{FilePath=$_.path;Date=($_.date | get-date)} }
 
             Write-Output $Result
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
     }
@@ -31591,13 +31596,13 @@ function Global:Get-OciBackups {
 #>
 function Global:Get-OciQueries {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                    Position=0,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         Write-Warning "This Cmdlet uses an undocumented API call which may change in the future. Thus this Cmdlet is marked as experimental!"
         $Result = $null
@@ -31605,20 +31610,20 @@ function Global:Get-OciQueries {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/queries"
- 
+
         try {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
 
         # TODO: implement parsing
@@ -31639,7 +31644,7 @@ function Global:Get-OciQueries {
 #>
 function Global:Get-OciQuery {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -31650,7 +31655,7 @@ function Global:Get-OciQuery {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         Write-Warning "This Cmdlet uses an undocumented API call which may change in the future. Thus this Cmdlet is marked as experimental!"
         $Result = $null
@@ -31658,20 +31663,20 @@ function Global:Get-OciQuery {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/queries/$id"
- 
+
         try {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
 
         # TODO: implement parsing
@@ -31692,7 +31697,7 @@ function Global:Get-OciQuery {
 #>
 function Global:Delete-OciQuery {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -31703,7 +31708,7 @@ function Global:Delete-OciQuery {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         Write-Warning "This Cmdlet uses an undocumented API call which may change in the future. Thus this Cmdlet is marked as experimental!"
         $Result = $null
@@ -31711,20 +31716,20 @@ function Global:Delete-OciQuery {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/queries/$id"
- 
+
         try {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "DELETE to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
 
         # TODO: implement parsing
@@ -31743,13 +31748,13 @@ function Global:Delete-OciQuery {
 #>
 function Global:Get-OciAnnotationRules {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$False,
                    Position=0,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         Write-Warning "This Cmdlet uses an undocumented API call which may change in the future. Thus this Cmdlet is marked as experimental!"
         $Result = $null
@@ -31757,20 +31762,20 @@ function Global:Get-OciAnnotationRules {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/admin/rules"
- 
+
         try {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
 
         # TODO: implement parsing
@@ -31789,7 +31794,7 @@ function Global:Get-OciAnnotationRules {
 #>
 function Global:Get-OciAnnotationRule {
     [CmdletBinding()]
- 
+
     PARAM (
         [parameter(Mandatory=$True,
                     Position=0,
@@ -31800,7 +31805,7 @@ function Global:Get-OciAnnotationRule {
                    Position=1,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
+
     Begin {
         Write-Warning "This Cmdlet uses an undocumented API call which may change in the future. Thus this Cmdlet is marked as experimental!"
         $Result = $null
@@ -31808,20 +31813,20 @@ function Global:Get-OciAnnotationRule {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
     }
-   
+
     Process {
         $Uri = $Server.BaseUri + "/rest/v1/admin/rules/$id"
- 
+
         try {
             $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method GET -Uri $Uri -Headers $Server.Headers
         }
         catch {
-            $ResponseBody = ParseExceptionBody $_.Exception.Response
+            $ResponseBody = ParseExceptionBody -Response $_.Exception.Response
             Write-Error "GET to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"
         }
- 
+
         if (([String]$Result).Trim().startsWith('{') -or ([String]$Result).toString().Trim().startsWith('[')) {
-            $Result = ParseJsonString($Result.Trim())
+            $Result = ParseJsonString -json $Result.Trim()
         }
 
         # TODO: implement parsing


### PR DESCRIPTION
Changed all function calls to use parameter names
 - The syntax: FunctionCall($param1, $param2) is invalid and errors were being thrown (a
   single parameter specified would work, but changed them all for consistency)
Fixed call to Get-OciDatastores
 - Previously committed changed was mistakenly overwritten (call to function specifying
   invalid parameters)
Fixed parameter name in ParseShares functions
 - Was $Qtrees, changed to $Shares
Removed trailing space characters
Replaced all aliases with full cmdlet names
 - select, %, ?, sleep, etc.