### PR TITLE
Updated functions to Bulk (un)assign an Application to multiple Assets

### DIFF
--- a/src/OnCommand-Insight.psm1
+++ b/src/OnCommand-Insight.psm1
@@ -6237,8 +6237,14 @@ function Global:Bulk-OciUnAssignApplicationFromAssets {
                     HelpMessage="Id of application to un-assign from assets",
                     ValueFromPipeline=$True,
                     ValueFromPipelineByPropertyName=$True)][Long[]]$id,
+		[parameter(Mandatory=$True,
+                    Position=1,
+                    HelpMessage="Array of OCI Object IDs to remove from the Application.")][String[]]$Assets,
+		[parameter(Mandatory=$True,
+                    Position=2,
+                    HelpMessage="Type of OCI asset to update VirtualMachine, Host etc..")][String]$AssetType,
         [parameter(Mandatory=$False,
-                   Position=1,
+                   Position=3,
                    HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
  
@@ -6263,6 +6269,7 @@ function Global:Bulk-OciUnAssignApplicationFromAssets {
    
     Process {
         $id = @($id)
+		$Targets = @($Assets)
         foreach ($id in $id) {
             $Uri = $Server.BaseUri + "/rest/v1/assets/applications/$id/assets"           
  
@@ -6283,13 +6290,11 @@ function Global:Bulk-OciUnAssignApplicationFromAssets {
             }
  
             try {
-                if ('DELETE' -match 'PUT|POST') {
-                    Write-Verbose "Body: "
-                    $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers -Body "" -ContentType 'application/json'
-                }
-                else {
-                    $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers
-                }
+				$Body = @{objectType=$AssetType;targets=$Targets} | ConvertTo-Json -Compress
+				$Body = $Body.Insert(0,'[')
+				$Body = $Body.Insert($Body.Length,']')
+                Write-Verbose "Body: "
+                $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method DELETE -Uri $Uri -Headers $Server.Headers -Body $Body -ContentType 'application/json'
             }
             catch {
                 $ResponseBody = ParseExceptionBody $_.Exception.Response
@@ -6422,16 +6427,29 @@ function Global:Bulk-OciAssignApplicationToAssets {
         [parameter(Mandatory=$True,
                     Position=0,
                     HelpMessage="Id of application to assign to assets",
-                    ValueFromPipeline=$True,
-                    ValueFromPipelineByPropertyName=$True)][Long[]]$id
+                    ValueFromPipeline=$False,
+                    ValueFromPipelineByPropertyName=$False)][Long[]]$id,
+		[parameter(Mandatory=$True,
+                    Position=1,
+                    HelpMessage="Array of OCI Object IDs to add the Application to.")][String[]]$Assets,
+		[parameter(Mandatory=$True,
+                    Position=2,
+                    HelpMessage="Type of OCI asset to update VirtualMachine, Host etc..")][String]$AssetType,
+		[parameter(Mandatory=$False,
+                   Position=3,
+                   HelpMessage="OnCommand Insight Server.")]$Server=$CurrentOciServer
     )
- 
-    Begin {
+	
+     Begin {
         $Result = $null
         if (!$Server) {
             throw "Server parameter not specified and no global OCI Server available. Run Connect-OciServer first!"
         }
 
+		if (!$assets) {
+            throw "No Assets specified!"
+        }
+		
         $switchparameters=@()
         foreach ($parameter in $switchparameters) {
             if ((Get-Variable $parameter).Value) {
@@ -6447,8 +6465,9 @@ function Global:Bulk-OciAssignApplicationToAssets {
    
     Process {
         $id = @($id)
+		$Targets = @($Assets)
         foreach ($id in $id) {
-            $Uri = $Server.BaseUri + "/rest/v1/assets/applications/$id/assets"
+		    $Uri = $Server.BaseUri + "/rest/v1/assets/applications/$id/assets"
  
             if ($fromTime -or $toTime -or $expand) {
                 $Uri += '?'
@@ -6465,16 +6484,14 @@ function Global:Bulk-OciAssignApplicationToAssets {
                     $Uri += "$($Separator)expand=$expand"
                 }
             }
- 
+
             try {
-                if ('PATCH' -match 'PUT|POST') {
-                    Write-Verbose "Body: "
-                    $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PATCH -Uri $Uri -Headers $Server.Headers -Body "" -ContentType 'application/json'
+				$Body = @{objectType=$AssetType;targets=$Targets} | ConvertTo-Json -Compress
+				$Body = $Body.Insert(0,'[')
+				$Body = $Body.Insert($Body.Length,']')
+                Write-Verbose "Body: $Body"
+                $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PATCH -Uri $Uri  -Body $Body -Headers $Server.Headers -ContentType 'application/json'
                 }
-                else {
-                    $Result = Invoke-RestMethod -WebSession $Server.Session -TimeoutSec $Server.Timeout -Method PATCH -Uri $Uri -Headers $Server.Headers
-                }
-            }
             catch {
                 $ResponseBody = ParseExceptionBody $_.Exception.Response
                 Write-Error "PATCH to $Uri failed with Exception $($_.Exception.Message) `n $responseBody"


### PR DESCRIPTION
Completed functions to add or remove a single Application to multiple OCI objects. Added AssetType parameter to make function reusable. Assets parameter expects an array of OCI object IDs.

Probably a neater way to do it but it's doing the job I need for now